### PR TITLE
feat(app, home): 홈페이지 내부를 React 컴포넌트로 분리하고, 공용 레이아웃으로 감싸도록 페이지 내부를 리팩토링합니다.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     'no-undef': 0,
     'prettier/prettier': 2, // Means error
     'react/react-in-jsx-scope': 'off',
+    'react/prop-types': 'off', // TypeScript 에서  이미 컴포넌트의 props를 검증하기 위해 타입 체크를 제공
   },
   settings: {
     react: {

--- a/apps/react-world/src/components/Footer.tsx
+++ b/apps/react-world/src/components/Footer.tsx
@@ -1,0 +1,16 @@
+export const Footer: React.FC = () => {
+  return (
+    <footer>
+      <div className="container">
+        <a href="/" className="logo-font">
+          conduit
+        </a>
+        <span className="attribution">
+          An interactive learning project from{' '}
+          <a href="https://thinkster.io">Thinkster</a>. Code &amp; design
+          licensed under MIT.
+        </span>
+      </div>
+    </footer>
+  );
+};

--- a/apps/react-world/src/components/Layout.tsx
+++ b/apps/react-world/src/components/Layout.tsx
@@ -1,0 +1,15 @@
+import { PropsWithChildren } from 'react';
+import { Navbar } from '../components/NavBar';
+import { Footer } from '../components/Footer';
+
+type LayoutProps = PropsWithChildren;
+
+export const Layout = ({ children }: LayoutProps) => {
+  return (
+    <>
+      <Navbar />
+      {children}
+      <Footer />
+    </>
+  );
+};

--- a/apps/react-world/src/components/NavBar.tsx
+++ b/apps/react-world/src/components/NavBar.tsx
@@ -1,0 +1,28 @@
+export const Navbar: React.FC = () => {
+  return (
+    <nav className="navbar navbar-light">
+      <div className="container">
+        <a className="navbar-brand" href="/">
+          conduit
+        </a>
+        <ul className="nav navbar-nav pull-xs-right">
+          <li className="nav-item">
+            <a className="nav-link active" href="/">
+              Home
+            </a>
+          </li>
+          <li className="nav-item">
+            <a className="nav-link" href="/login">
+              Sign in
+            </a>
+          </li>
+          <li className="nav-item">
+            <a className="nav-link" href="/register">
+              Sign up
+            </a>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  );
+};

--- a/apps/react-world/src/components/home/ArticlePreview.tsx
+++ b/apps/react-world/src/components/home/ArticlePreview.tsx
@@ -1,0 +1,54 @@
+interface ArticlePreviewProps {
+  authorProfileLink: string;
+  authorProfileImageUrl: string;
+  authorName: string;
+  publishDate: string;
+  likeCount: number;
+  articleLink: string;
+  articleTitle: string;
+  articleDescription: string;
+  tags: string[];
+}
+
+const ArticlePreview: React.FC<ArticlePreviewProps> = ({
+  authorProfileLink,
+  authorProfileImageUrl,
+  authorName,
+  publishDate,
+  likeCount,
+  articleLink,
+  articleTitle,
+  articleDescription,
+  tags,
+}) => (
+  <div className="article-preview">
+    <div className="article-meta">
+      <a href={authorProfileLink}>
+        <img src={authorProfileImageUrl} />
+      </a>
+      <div className="info">
+        <a href={authorProfileLink} className="author">
+          {authorName}
+        </a>
+        <span className="date">{publishDate}</span>
+      </div>
+      <button className="btn btn-outline-primary btn-sm pull-xs-right">
+        <i className="ion-heart"></i> {likeCount}
+      </button>
+    </div>
+    <a href={articleLink} className="preview-link">
+      <h1>{articleTitle}</h1>
+      <p>{articleDescription}</p>
+      <span>Read more...</span>
+      <ul className="tag-list">
+        {tags.map(tag => (
+          <li className="tag-default tag-pill tag-outline" key={tag}>
+            {tag}
+          </li>
+        ))}
+      </ul>
+    </a>
+  </div>
+);
+
+export default ArticlePreview;

--- a/apps/react-world/src/components/home/ArticleTagList.tsx
+++ b/apps/react-world/src/components/home/ArticleTagList.tsx
@@ -1,0 +1,20 @@
+interface ArticleTagListProps {
+  tags: string[];
+}
+
+const ArticleTagList: React.FC<ArticleTagListProps> = ({ tags }) => (
+  <div className="col-md-3">
+    <div className="sidebar">
+      <p>Popular Tags</p>
+      <div className="tag-list">
+        {tags.map(tag => (
+          <a key={tag} href="" className="tag-pill tag-default">
+            {tag}
+          </a>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+export default ArticleTagList;

--- a/apps/react-world/src/components/home/HomeBanner.tsx
+++ b/apps/react-world/src/components/home/HomeBanner.tsx
@@ -1,0 +1,12 @@
+export const HomeBanner: React.FC = () => {
+  return (
+    <div className="home-page">
+      <div className="banner">
+        <div className="container">
+          <h1 className="logo-font">conduit</h1>
+          <p>A place to share your knowledge.</p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/react-world/src/components/home/HomeFeedContents.tsx
+++ b/apps/react-world/src/components/home/HomeFeedContents.tsx
@@ -1,0 +1,53 @@
+import ArticlePreview from './ArticlePreview';
+import ArticleTagList from './ArticleTagList';
+import HomeFeedTab from './HomeFeedTab';
+import Pagination from './Pagination';
+
+const HomeFeedContents: React.FC = () => (
+  <div className="container page">
+    <div className="row">
+      <div className="col-md-9">
+        <HomeFeedTab activeFeed="global_feed" />
+        {/* 더미 데이터 */}
+        <ArticlePreview
+          authorProfileLink="/profile/eric-simons"
+          authorProfileImageUrl="http://i.imgur.com/Qr71crq.jpg"
+          authorName="Eric Simons"
+          publishDate="January 20th"
+          likeCount={29}
+          articleLink="/article/how-to-build-webapps-that-scale"
+          articleTitle="How to build webapps that scale"
+          articleDescription="This is the description for the post."
+          tags={['realworld', 'implementations']}
+        />
+        <ArticlePreview
+          authorProfileLink="/profile/albert-pai"
+          authorProfileImageUrl="http://i.imgur.com/N4VcUeJ.jpg"
+          authorName="Albert Pai"
+          publishDate="January 20th"
+          likeCount={32}
+          articleLink="/article/the-song-you"
+          articleTitle="The song you won't ever stop singing. No matter how hard you try."
+          articleDescription="This is the description for the post."
+          tags={['realworld', 'implementations']}
+        />
+        <Pagination pages={[1, 2]} activePage={1} />
+      </div>
+
+      <ArticleTagList
+        tags={[
+          'programming',
+          'javascript',
+          'emberjs',
+          'angularjs',
+          'react',
+          'mean',
+          'node',
+          'rails',
+        ]}
+      />
+    </div>
+  </div>
+);
+
+export default HomeFeedContents;

--- a/apps/react-world/src/components/home/HomeFeedTab.tsx
+++ b/apps/react-world/src/components/home/HomeFeedTab.tsx
@@ -1,0 +1,28 @@
+interface HomeFeedTabProps {
+  activeFeed: 'my_feed' | 'global_feed';
+}
+
+const HomeFeedTab: React.FC<HomeFeedTabProps> = ({ activeFeed }) => (
+  <div className="feed-toggle">
+    <ul className="nav nav-pills outline-active">
+      <li className="nav-item">
+        <a
+          className={`nav-link ${activeFeed === 'my_feed' ? 'active' : ''}`}
+          href=""
+        >
+          Your Feed
+        </a>
+      </li>
+      <li className="nav-item">
+        <a
+          className={`nav-link ${activeFeed === 'global_feed' ? 'active' : ''}`}
+          href=""
+        >
+          Global Feed
+        </a>
+      </li>
+    </ul>
+  </div>
+);
+
+export default HomeFeedTab;

--- a/apps/react-world/src/components/home/HomePageContainer.tsx
+++ b/apps/react-world/src/components/home/HomePageContainer.tsx
@@ -1,0 +1,9 @@
+interface HomePageContainerProps {
+  children: React.ReactNode;
+}
+
+const HomePageContainer: React.FC<HomePageContainerProps> = ({ children }) => {
+  return <div className="home-page">{children}</div>;
+};
+
+export default HomePageContainer;

--- a/apps/react-world/src/components/home/Pagination.tsx
+++ b/apps/react-world/src/components/home/Pagination.tsx
@@ -1,0 +1,23 @@
+interface PaginationProps {
+  pages: number[];
+  activePage: number;
+}
+
+const Pagination: React.FC<PaginationProps> = ({ pages, activePage }) => {
+  return (
+    <ul className="pagination">
+      {pages.map(page => (
+        <li
+          key={page}
+          className={`page-item ${page === activePage ? 'active' : ''}`}
+        >
+          <a className="page-link" href="">
+            {page}
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default Pagination;

--- a/apps/react-world/src/pages/home.tsx
+++ b/apps/react-world/src/pages/home.tsx
@@ -1,185 +1,68 @@
+import { Navbar } from '../components/NavBar';
+import { HomeBanner } from '../components/home/HomeBanner';
+import { Footer } from '../components/Footer';
+import HomeFeedTab from '../components/home/HomeFeedTab';
+import ArticleTagList from '../components/home/ArticleTagList';
+import ArticlePreview from '../components/home/ArticlePreview';
+import Pagination from '../components/home/Pagination';
+
 export const HomePage = () => {
   return (
     <>
-      <nav className="navbar navbar-light">
-        <div className="container">
-          <a className="navbar-brand" href="/">
-            conduit
-          </a>
-          <ul className="nav navbar-nav pull-xs-right">
-            <li className="nav-item">
-              <a className="nav-link active" href="/">
-                Home
-              </a>
-            </li>
-            <li className="nav-item">
-              <a className="nav-link" href="/login">
-                Sign in
-              </a>
-            </li>
-            <li className="nav-item">
-              <a className="nav-link" href="/register">
-                Sign up
-              </a>
-            </li>
-          </ul>
-        </div>
-      </nav>
+      <Navbar />
 
       <div className="home-page">
-        <div className="banner">
-          <div className="container">
-            <h1 className="logo-font">conduit</h1>
-            <p>A place to share your knowledge.</p>
-          </div>
-        </div>
+        <HomeBanner />
 
         <div className="container page">
           <div className="row">
             <div className="col-md-9">
-              <div className="feed-toggle">
-                <ul className="nav nav-pills outline-active">
-                  <li className="nav-item">
-                    <a className="nav-link" href="">
-                      Your Feed
-                    </a>
-                  </li>
-                  <li className="nav-item">
-                    <a className="nav-link active" href="">
-                      Global Feed
-                    </a>
-                  </li>
-                </ul>
-              </div>
+              <HomeFeedTab activeFeed="global_feed" />
 
-              <div className="article-preview">
-                <div className="article-meta">
-                  <a href="/profile/eric-simons">
-                    <img src="http://i.imgur.com/Qr71crq.jpg" />
-                  </a>
-                  <div className="info">
-                    <a href="/profile/eric-simons" className="author">
-                      Eric Simons
-                    </a>
-                    <span className="date">January 20th</span>
-                  </div>
-                  <button className="btn btn-outline-primary btn-sm pull-xs-right">
-                    <i className="ion-heart"></i> 29
-                  </button>
-                </div>
-                <a
-                  href="/article/how-to-build-webapps-that-scale"
-                  className="preview-link"
-                >
-                  <h1>How to build webapps that scale</h1>
-                  <p>This is the description for the post.</p>
-                  <span>Read more...</span>
-                  <ul className="tag-list">
-                    <li className="tag-default tag-pill tag-outline">
-                      realworld
-                    </li>
-                    <li className="tag-default tag-pill tag-outline">
-                      implementations
-                    </li>
-                  </ul>
-                </a>
-              </div>
+              <ArticlePreview
+                authorProfileLink="/profile/eric-simons"
+                authorProfileImageUrl="http://i.imgur.com/Qr71crq.jpg"
+                authorName="Eric Simons"
+                publishDate="January 20th"
+                likeCount={29}
+                articleLink="/article/how-to-build-webapps-that-scale"
+                articleTitle="How to build webapps that scale"
+                articleDescription="This is the description for the post."
+                tags={['realworld', 'implementations']}
+              />
 
-              <div className="article-preview">
-                <div className="article-meta">
-                  <a href="/profile/albert-pai">
-                    <img src="http://i.imgur.com/N4VcUeJ.jpg" />
-                  </a>
-                  <div className="info">
-                    <a href="/profile/albert-pai" className="author">
-                      Albert Pai
-                    </a>
-                    <span className="date">January 20th</span>
-                  </div>
-                  <button className="btn btn-outline-primary btn-sm pull-xs-right">
-                    <i className="ion-heart"></i> 32
-                  </button>
-                </div>
-                <a href="/article/the-song-you" className="preview-link">
-                  <h1>
-                    The song you won&apos;t ever stop singing. No matter how
-                    hard you try.
-                  </h1>
-                  <p>This is the description for the post.</p>
-                  <span>Read more...</span>
-                  <ul className="tag-list">
-                    <li className="tag-default tag-pill tag-outline">
-                      realworld
-                    </li>
-                    <li className="tag-default tag-pill tag-outline">
-                      implementations
-                    </li>
-                  </ul>
-                </a>
-              </div>
+              <ArticlePreview
+                authorProfileLink="/profile/albert-pai"
+                authorProfileImageUrl="http://i.imgur.com/N4VcUeJ.jpg"
+                authorName="Albert Pai"
+                publishDate="January 20th"
+                likeCount={32}
+                articleLink="/article/the-song-you"
+                articleTitle="The song you won't ever stop singing. No matter how hard you try."
+                articleDescription="This is the description for the post."
+                tags={['realworld', 'implementations']}
+              />
 
-              <ul className="pagination">
-                <li className="page-item active">
-                  <a className="page-link" href="">
-                    1
-                  </a>
-                </li>
-                <li className="page-item">
-                  <a className="page-link" href="">
-                    2
-                  </a>
-                </li>
-              </ul>
+              <Pagination pages={[1, 2]} activePage={1} />
             </div>
 
-            <div className="col-md-3">
-              <div className="sidebar">
-                <p>Popular Tags</p>
-
-                <div className="tag-list">
-                  <a href="" className="tag-pill tag-default">
-                    programming
-                  </a>
-                  <a href="" className="tag-pill tag-default">
-                    javascript
-                  </a>
-                  <a href="" className="tag-pill tag-default">
-                    emberjs
-                  </a>
-                  <a href="" className="tag-pill tag-default">
-                    angularjs
-                  </a>
-                  <a href="" className="tag-pill tag-default">
-                    react
-                  </a>
-                  <a href="" className="tag-pill tag-default">
-                    mean
-                  </a>
-                  <a href="" className="tag-pill tag-default">
-                    node
-                  </a>
-                  <a href="" className="tag-pill tag-default">
-                    rails
-                  </a>
-                </div>
-              </div>
-            </div>
+            <ArticleTagList
+              tags={[
+                'programming',
+                'javascript',
+                'emberjs',
+                'angularjs',
+                'react',
+                'mean',
+                'node',
+                'rails',
+              ]}
+            />
           </div>
         </div>
       </div>
 
-      <footer>
-        <div className="container">
-          <a href="/" className="logo-font">
-            conduit
-          </a>
-          <span className="attribution">
-            An interactive learning project from{' '}
-            <a href="https://thinkster.io">Thinkster</a>. Code &amp; design
-            licensed under MIT.
-          </span>
-        </div>
-      </footer>
+      <Footer />
     </>
   );
 };

--- a/apps/react-world/src/pages/home.tsx
+++ b/apps/react-world/src/pages/home.tsx
@@ -1,68 +1,12 @@
-import { Navbar } from '../components/NavBar';
+import HomePageContainer from '../components/home/HomePageContainer';
 import { HomeBanner } from '../components/home/HomeBanner';
-import { Footer } from '../components/Footer';
-import HomeFeedTab from '../components/home/HomeFeedTab';
-import ArticleTagList from '../components/home/ArticleTagList';
-import ArticlePreview from '../components/home/ArticlePreview';
-import Pagination from '../components/home/Pagination';
+import HomeFeedContents from '../components/home/HomeFeedContents';
 
 export const HomePage = () => {
   return (
-    <>
-      <Navbar />
-
-      <div className="home-page">
-        <HomeBanner />
-
-        <div className="container page">
-          <div className="row">
-            <div className="col-md-9">
-              <HomeFeedTab activeFeed="global_feed" />
-
-              <ArticlePreview
-                authorProfileLink="/profile/eric-simons"
-                authorProfileImageUrl="http://i.imgur.com/Qr71crq.jpg"
-                authorName="Eric Simons"
-                publishDate="January 20th"
-                likeCount={29}
-                articleLink="/article/how-to-build-webapps-that-scale"
-                articleTitle="How to build webapps that scale"
-                articleDescription="This is the description for the post."
-                tags={['realworld', 'implementations']}
-              />
-
-              <ArticlePreview
-                authorProfileLink="/profile/albert-pai"
-                authorProfileImageUrl="http://i.imgur.com/N4VcUeJ.jpg"
-                authorName="Albert Pai"
-                publishDate="January 20th"
-                likeCount={32}
-                articleLink="/article/the-song-you"
-                articleTitle="The song you won't ever stop singing. No matter how hard you try."
-                articleDescription="This is the description for the post."
-                tags={['realworld', 'implementations']}
-              />
-
-              <Pagination pages={[1, 2]} activePage={1} />
-            </div>
-
-            <ArticleTagList
-              tags={[
-                'programming',
-                'javascript',
-                'emberjs',
-                'angularjs',
-                'react',
-                'mean',
-                'node',
-                'rails',
-              ]}
-            />
-          </div>
-        </div>
-      </div>
-
-      <Footer />
-    </>
+    <HomePageContainer>
+      <HomeBanner />
+      <HomeFeedContents />
+    </HomePageContainer>
   );
 };

--- a/apps/react-world/src/routes/Routes.tsx
+++ b/apps/react-world/src/routes/Routes.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { Layout } from '../components/Layout';
 import { HomePage } from '../pages/home';
 import { LoginPage } from '../pages/login';
 import { RegisterPage } from '../pages/register';
@@ -39,5 +40,9 @@ const router = createBrowserRouter([
 ]);
 
 export const Routes = () => {
-  return <RouterProvider router={router} />;
+  return (
+    <Layout>
+      <RouterProvider router={router} />;
+    </Layout>
+  );
 };


### PR DESCRIPTION
## 📌 이슈 링크
- close https://github.com/pagers-org/react-world/issues/47

<br/>

## 📖 작업 배경

- JWT 인증 쪽 개발을 잠시 홀딩하고, 홈페이지 내부를 React 컴포넌트로 분리하고 내부를 정리하는 작업을 먼저 진행하려고 합니다.

<br/>

## 🛠️ 구현 내용

- 홈페이지 내부를 각각의 React 컴포넌트로 만들고 전부 분리합니다. 
- 홈페이지 내부 중 컨텐츠 영역을 HomeFeedContents 로 정의하고 분리합니다.
- 홈페이지 최상위 Wrapper 영역을 HomePageContainer 로 정의하고 분리합니다.
- 홈페이지를 비롯 각 페이지에서 공통으로 사용할 영역을 Layout 컴포넌트로 분리합니다. (@InSeong-So 님과 페어했습니다 💪)
- Router 에서 라우팅을 할 때 Layout 컴포넌트로 감싸서 라우팅을 하도록 해 모든 페이지에서 네비바와 푸터를 공용으로 사용할 수 있도록 합니다.

<br/>

## 💡 참고사항

- 평소 작업 방식이라면 이것보다 훨씬 더 작은 단위로 나눌 것 같기는 한데, 아직은 코딩 자체가 익숙하지 않다 보니 작업 단위가 커지는군요 😂 
- 일단 컴포넌트 분리부터 여러 페이지에 대해 최대한 많이 해두는 방향의 작업도 나쁘지 않겠다는 생각이 들었습니다.
- JWT 핸들링 쪽도 개발도 하긴 해야 할 텐데 어떤 것부터 할지 고민이네요 ㅎㅎ
- 여기까지 개발하면서 이제 폴더 구조에 대한 고민을 조금씩 하기 시작했는데, @InSeong-So 님과 이런저런 방향으로 얘기 나눠본 결과 지금 구조에서 아주 크게 바꿀 필요는 없을 것 같고 조금씩 바꾸어 나가는 수준으로만 일단 가도 될 것 같네요!

<br/>

## 🖼️ 스크린샷

리액트로 전부 분리한 다음 동일한 결과물임을 확인하는 스크린샷입니다. 

<img width="1061" alt="Screenshot 2023-09-07 at 10 38 52 PM" src="https://github.com/pagers-org/react-world/assets/2222333/f5b29760-9110-4ba2-84f9-dbf76540d885">

