### PR TITLE
fix(app): 프로젝트 내에서 React.FC 를 안 쓰도록 리팩토링합니다.

### DIFF
--- a/apps/react-world/src/components/Footer.tsx
+++ b/apps/react-world/src/components/Footer.tsx
@@ -1,4 +1,4 @@
-export const Footer: React.FC = () => {
+export const Footer = () => {
   return (
     <footer>
       <div className="container">

--- a/apps/react-world/src/components/home/ArticlePreview.tsx
+++ b/apps/react-world/src/components/home/ArticlePreview.tsx
@@ -10,7 +10,7 @@ interface ArticlePreviewProps {
   tags: string[];
 }
 
-const ArticlePreview: React.FC<ArticlePreviewProps> = ({
+const ArticlePreview = ({
   authorProfileLink,
   authorProfileImageUrl,
   authorName,
@@ -20,7 +20,7 @@ const ArticlePreview: React.FC<ArticlePreviewProps> = ({
   articleTitle,
   articleDescription,
   tags,
-}) => (
+}: ArticlePreviewProps) => (
   <div className="article-preview">
     <div className="article-meta">
       <a href={authorProfileLink}>

--- a/apps/react-world/src/components/home/ArticleTagList.tsx
+++ b/apps/react-world/src/components/home/ArticleTagList.tsx
@@ -2,7 +2,7 @@ interface ArticleTagListProps {
   tags: string[];
 }
 
-const ArticleTagList: React.FC<ArticleTagListProps> = ({ tags }) => (
+const ArticleTagList = ({ tags }: ArticleTagListProps) => (
   <div className="col-md-3">
     <div className="sidebar">
       <p>Popular Tags</p>

--- a/apps/react-world/src/components/home/HomeBanner.tsx
+++ b/apps/react-world/src/components/home/HomeBanner.tsx
@@ -4,7 +4,7 @@ import {
   HomeBannerTitle,
 } from './HomeBanner.styled';
 
-export const HomeBanner: React.FC = () => {
+export const HomeBanner = () => {
   return (
     <HomeBannerContainer>
       <HomeBannerTitle>conduit</HomeBannerTitle>

--- a/apps/react-world/src/components/home/HomeFeedContents.tsx
+++ b/apps/react-world/src/components/home/HomeFeedContents.tsx
@@ -3,7 +3,7 @@ import ArticleTagList from './ArticleTagList';
 import HomeFeedTab from './HomeFeedTab';
 import Pagination from './Pagination';
 
-const HomeFeedContents: React.FC = () => (
+const HomeFeedContents = () => (
   <div className="container page">
     <div className="row">
       <div className="col-md-9">

--- a/apps/react-world/src/components/home/HomeFeedTab.tsx
+++ b/apps/react-world/src/components/home/HomeFeedTab.tsx
@@ -2,7 +2,7 @@ interface HomeFeedTabProps {
   activeFeed: 'my_feed' | 'global_feed';
 }
 
-const HomeFeedTab: React.FC<HomeFeedTabProps> = ({ activeFeed }) => (
+const HomeFeedTab = ({ activeFeed }: HomeFeedTabProps) => (
   <div className="feed-toggle">
     <ul className="nav nav-pills outline-active">
       <li className="nav-item">

--- a/apps/react-world/src/components/home/Pagination.tsx
+++ b/apps/react-world/src/components/home/Pagination.tsx
@@ -3,7 +3,7 @@ interface PaginationProps {
   activePage: number;
 }
 
-const Pagination: React.FC<PaginationProps> = ({ pages, activePage }) => {
+const Pagination = ({ pages, activePage }: PaginationProps) => {
   return (
     <ul className="pagination">
       {pages.map(page => (

--- a/apps/react-world/src/components/shared/layout/Footer.tsx
+++ b/apps/react-world/src/components/shared/layout/Footer.tsx
@@ -1,4 +1,4 @@
-export const Footer: React.FC = () => {
+export const Footer = () => {
   return (
     <footer>
       <div className="container">

--- a/apps/react-world/src/components/shared/layout/NavBar/NavBar.tsx
+++ b/apps/react-world/src/components/shared/layout/NavBar/NavBar.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { Container } from '../../Container';
 import { NavItem } from './NavItem';
 import { NavbarBrand } from './NavBarBrand';
 import { NavList } from './NavList';
 
-export const Navbar: React.FC = () => {
+export const Navbar = () => {
   return (
     <NavbarContainer>
       <Container>

--- a/apps/react-world/src/components/shared/layout/NavBar/NavItem.tsx
+++ b/apps/react-world/src/components/shared/layout/NavBar/NavItem.tsx
@@ -7,7 +7,7 @@ interface NavItemProps {
   title: string;
 }
 
-export const NavItem: React.FC<NavItemProps> = ({ href, isActive, title }) => (
+export const NavItem = ({ href, isActive, title }: NavItemProps) => (
   <li className="nav-item">
     <NavLink className={`nav-link ${isActive ? 'active' : ''}`} href={href}>
       {title}

--- a/apps/react-world/src/pages/register.tsx
+++ b/apps/react-world/src/pages/register.tsx
@@ -1,6 +1,6 @@
 import useRegister from '../hooks/useRegister';
 
-export const RegisterPage: React.FC = () => {
+export const RegisterPage = () => {
   const { userData, error, isLoading, handleInputChange, handleSubmit } =
     useRegister();
 


### PR DESCRIPTION
## 📖 작업 배경

- https://github.com/pagers-org/react-world/pull/77#discussion_r1320514316 코멘트를 반영합니다.

<br/>

## 🛠️ 구현 내용

- React.FC 를 쓰지 않고 (필요한 경우) props 의 타입을 직접 지정하도록 로직을 변경합니다.
