### PR TITLE
refactor(app): API Path 를 선언하는 방식을 개선합니다.

### DIFF
--- a/apps/react-world/src/apis/ApiConstants.ts
+++ b/apps/react-world/src/apis/ApiConstants.ts
@@ -1,7 +1,0 @@
-export const BASE_URL = 'https://api.realworld.io/api';
-
-export const API_PATH = {
-  USERS: {
-    REGISTER: '/users',
-  },
-};

--- a/apps/react-world/src/apis/ApiConstants.ts
+++ b/apps/react-world/src/apis/ApiConstants.ts
@@ -1,3 +1,7 @@
 export const BASE_URL = 'https://api.realworld.io/api';
 
-export const REGISTER_USER_API_PATH = '/users';
+export const API_PATH = {
+  USERS: {
+    REGISTER: '/users',
+  },
+};

--- a/apps/react-world/src/apis/apiInstances.ts
+++ b/apps/react-world/src/apis/apiInstances.ts
@@ -1,0 +1,24 @@
+import axios, { AxiosRequestConfig } from 'axios';
+
+// TODO: 향후 .env 파일로 분리
+const BASE_URL = 'https://api.realworld.io/api';
+
+// 단순 GET 요청으로 인증이 필요없는 경우
+const axiosApi = (url: string, options?: AxiosRequestConfig) => {
+  const instance = axios.create({ baseURL: url, ...options });
+  return instance;
+};
+
+// POST, DELETE 등 요청 시 인증이 필요한 경우
+const axiosAuthApi = (url: string, options?: AxiosRequestConfig) => {
+  const jwtToken = '토큰 값'; // TODO: 향후 개발
+  const instance = axios.create({
+    baseURL: url,
+    headers: { Authorization: 'Bearer ' + jwtToken },
+    ...options,
+  });
+  return instance;
+};
+
+export const api = axiosApi(BASE_URL);
+export const authApi = axiosAuthApi(BASE_URL);

--- a/apps/react-world/src/apis/register/RegisterService.ts
+++ b/apps/react-world/src/apis/register/RegisterService.ts
@@ -4,13 +4,13 @@ import {
   RegisterUserErrors,
   RegisterUserResponse,
 } from './RegisterService.types';
-import { BASE_URL, REGISTER_USER_API_PATH } from '../ApiConstants';
+import { BASE_URL, API_PATH } from '../ApiConstants';
 
 class RegisterService {
   static async registerUser(
     userData: RegisterUserParams,
   ): Promise<RegisterUserResponse> {
-    const ENDPOINT = `${BASE_URL}${REGISTER_USER_API_PATH}`;
+    const ENDPOINT = `${BASE_URL}${API_PATH.USERS.REGISTER}`;
 
     try {
       const response = await axios.post(ENDPOINT, {

--- a/apps/react-world/src/apis/register/RegisterService.ts
+++ b/apps/react-world/src/apis/register/RegisterService.ts
@@ -1,27 +1,22 @@
-import axios, { AxiosError } from 'axios';
+import { isAxiosError } from 'axios';
 import {
   RegisterUserParams,
-  RegisterUserErrors,
   RegisterUserResponse,
 } from './RegisterService.types';
-import { BASE_URL, API_PATH } from '../ApiConstants';
+import { api } from '../apiInstances';
 
 class RegisterService {
   static async registerUser(
     userData: RegisterUserParams,
   ): Promise<RegisterUserResponse> {
-    const ENDPOINT = `${BASE_URL}${API_PATH.USERS.REGISTER}`;
-
     try {
-      const response = await axios.post(ENDPOINT, {
+      const response = await api.post('/users', {
         user: userData,
       });
       return response.data;
     } catch (error) {
-      const axiosError = error as AxiosError<RegisterUserErrors>;
-
-      if (axiosError && axiosError.response) {
-        throw axiosError.response.data;
+      if (isAxiosError(error) && error.response) {
+        throw error.response.data;
       }
       throw error;
     }


### PR DESCRIPTION
## 📌 이슈 링크
- #59


<br/>

## 📖 작업 배경

- 위 PR에서 @areumsheep 님께서 주신 코멘트를 반영합니다.
  - https://github.com/pagers-org/react-world/pull/59#discussion_r1320593757

<br/>

## 🛠️ 구현 내용

- API_PATH 를 기존 개별 선언하는 형태에서, 앞으로 확장 가능한 형태로 Object 형태로 변경합니다.

<br/>

## 💡 리뷰 노트

- 혹시 여기서도 더 발전할 수 있는 형태가 있는지도 궁금하네요! @InSeong-So 

<br/>
