### PR TITLE
refactor(home): 홈 페이지의 아티클 프리뷰 컴포넌트를 styled component 기반으로 리팩토링합니다.

### DIFF
--- a/apps/react-world/src/apis/article/ArticlePreviewService.types.ts
+++ b/apps/react-world/src/apis/article/ArticlePreviewService.types.ts
@@ -1,0 +1,11 @@
+export interface ArticlePreviewResponse {
+  authorProfileLink: string;
+  authorProfileImageUrl: string;
+  authorName: string;
+  publishDate: string;
+  likeCount: number;
+  articleLink: string;
+  articleTitle: string;
+  articleDescription: string;
+  tags: string[];
+}

--- a/apps/react-world/src/components/home/ArticlePreview.styled.ts
+++ b/apps/react-world/src/components/home/ArticlePreview.styled.ts
@@ -1,0 +1,123 @@
+import styled from '@emotion/styled';
+
+export const ArticlePreviewContainer = styled.div`
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  padding: 1.5rem 0;
+`;
+
+export const ArticlePreviewMeta = styled.div`
+  margin: 0 0 1rem 0;
+  display: flex;
+  align-items: center;
+`;
+
+export const AuthorProfileLink = styled.a`
+  display: block;
+`;
+
+export const AuthorProfileImage = styled.img`
+  display: inline-block;
+  vertical-align: middle;
+  height: 32px;
+  width: 32px;
+  border-radius: 30px;
+`;
+
+export const AuthorInfo = styled.div`
+  margin: 0 1.5rem 0 0.3rem;
+  display: inline-block;
+  vertical-align: middle;
+  line-height: 1rem;
+`;
+
+export const Author = styled.a`
+  display: block;
+  font-weight: 500;
+`;
+
+export const PublishedDate = styled.span`
+  color: #bbb;
+  font-size: 0.8rem;
+  display: block;
+`;
+
+export const LikeButton = styled.button`
+  display: inline-flex;
+  padding: 0.25rem 0.5rem;
+  align-items: center;
+  background-color: transparent;
+  border: 1px solid transparent;
+  border-color: #5cb85c;
+  border-radius: 0.2rem;
+  color: #5cb85c;
+  font-size: 0.875rem;
+  display: inline-block;
+  font-weight: normal;
+  line-height: 1.25;
+  text-align: center;
+  user-select: none;
+  cursor: pointer;
+  margin-left: auto; /* 오른쪽으로 붙이기 위해 추가 */
+
+  &:hover {
+    color: #fff;
+    background-color: #5cb85c;
+  }
+`;
+
+export const ArticlePreviewLink = styled.a`
+  color: inherit;
+
+  &:hover {
+    color: inherit; // Keep default color on hover
+    text-decoration: none; // Remove underline on hover as well
+  }
+`;
+
+export const ArticleTitle = styled.h1`
+  font-weight: 600;
+  font-size: 1.5rem;
+  margin-bottom: 3px;
+`;
+
+export const ArticleDescription = styled.p`
+  font-weight: 300;
+  font-size: 24px;
+  color: #999;
+  margin-bottom: 15px;
+  font-size: 1rem;
+  line-height: 1.3rem;
+`;
+
+export const ReadMore = styled.span`
+  max-width: 30%;
+  font-size: 0.8rem;
+  font-weight: 300;
+  color: #bbb;
+  vertical-align: middle;
+`;
+
+export const TagList = styled.ul`
+  float: right;
+  max-width: 50%;
+  vertical-align: top;
+  padding-left: 0px;
+`;
+
+export const TagItem = styled.li`
+  display: inline-block;
+  border: 1px solid #ddd;
+  color: #aaa;
+  background: none;
+  padding-right: 0.6em;
+  padding-left: 0.6em;
+  border-radius: 10rem;
+  margin-right: 3px;
+  margin-bottom: 0.2rem;
+
+  font-weight: 300;
+  font-size: 0.8rem;
+  list-style: none;
+
+  cursor: pointer;
+`;

--- a/apps/react-world/src/components/home/ArticlePreview.tsx
+++ b/apps/react-world/src/components/home/ArticlePreview.tsx
@@ -1,54 +1,60 @@
+import type { ArticlePreviewResponse } from '../../apis/article/ArticlePreviewService.types';
+import {
+  ArticlePreviewContainer,
+  ArticlePreviewMeta,
+  AuthorProfileLink,
+  AuthorProfileImage,
+  AuthorInfo,
+  Author,
+  PublishedDate,
+  LikeButton,
+  ArticlePreviewLink,
+  ArticleTitle,
+  ArticleDescription,
+  ReadMore,
+  TagList,
+  TagItem,
+} from './ArticlePreview.styled';
+
 interface ArticlePreviewProps {
-  authorProfileLink: string;
-  authorProfileImageUrl: string;
-  authorName: string;
-  publishDate: string;
-  likeCount: number;
-  articleLink: string;
-  articleTitle: string;
-  articleDescription: string;
-  tags: string[];
+  articlePreview: ArticlePreviewResponse;
 }
 
 const ArticlePreview = ({
-  authorProfileLink,
-  authorProfileImageUrl,
-  authorName,
-  publishDate,
-  likeCount,
-  articleLink,
-  articleTitle,
-  articleDescription,
-  tags,
+  articlePreview: {
+    authorProfileLink,
+    authorProfileImageUrl,
+    authorName,
+    publishDate,
+    likeCount,
+    articleLink,
+    articleTitle,
+    articleDescription,
+    tags,
+  },
 }: ArticlePreviewProps) => (
-  <div className="article-preview">
-    <div className="article-meta">
-      <a href={authorProfileLink}>
-        <img src={authorProfileImageUrl} />
-      </a>
-      <div className="info">
-        <a href={authorProfileLink} className="author">
-          {authorName}
-        </a>
-        <span className="date">{publishDate}</span>
-      </div>
-      <button className="btn btn-outline-primary btn-sm pull-xs-right">
-        <i className="ion-heart"></i> {likeCount}
-      </button>
-    </div>
-    <a href={articleLink} className="preview-link">
-      <h1>{articleTitle}</h1>
-      <p>{articleDescription}</p>
-      <span>Read more...</span>
-      <ul className="tag-list">
+  <ArticlePreviewContainer>
+    <ArticlePreviewMeta>
+      <AuthorProfileLink href={authorProfileLink}>
+        <AuthorProfileImage src={authorProfileImageUrl} />
+      </AuthorProfileLink>
+      <AuthorInfo>
+        <Author href={authorProfileLink}>{authorName}</Author>
+        <PublishedDate>{publishDate}</PublishedDate>
+      </AuthorInfo>
+      <LikeButton>{likeCount}</LikeButton>
+    </ArticlePreviewMeta>
+    <ArticlePreviewLink href={articleLink}>
+      <ArticleTitle>{articleTitle}</ArticleTitle>
+      <ArticleDescription>{articleDescription}</ArticleDescription>
+      <ReadMore>Read more...</ReadMore>
+      <TagList>
         {tags.map(tag => (
-          <li className="tag-default tag-pill tag-outline" key={tag}>
-            {tag}
-          </li>
+          <TagItem key={tag}>{tag}</TagItem>
         ))}
-      </ul>
-    </a>
-  </div>
+      </TagList>
+    </ArticlePreviewLink>
+  </ArticlePreviewContainer>
 );
 
 export default ArticlePreview;

--- a/apps/react-world/src/components/home/HomeFeedContents.tsx
+++ b/apps/react-world/src/components/home/HomeFeedContents.tsx
@@ -11,26 +11,31 @@ const HomeFeedContents = () => (
         <HomeFeedTab activeFeed="global_feed" />
         {/* 더미 데이터 */}
         <ArticlePreview
-          authorProfileLink="/profile/eric-simons"
-          authorProfileImageUrl="http://i.imgur.com/Qr71crq.jpg"
-          authorName="Eric Simons"
-          publishDate="January 20th"
-          likeCount={29}
-          articleLink="/article/how-to-build-webapps-that-scale"
-          articleTitle="How to build webapps that scale"
-          articleDescription="This is the description for the post."
-          tags={['realworld', 'implementations']}
+          articlePreview={{
+            authorProfileLink: '/profile/eric-simons',
+            authorProfileImageUrl: 'http://i.imgur.com/Qr71crq.jpg',
+            authorName: 'Eric Simons',
+            publishDate: 'January 20th',
+            likeCount: 29,
+            articleLink: '/article/how-to-build-webapps-that-scale',
+            articleTitle: 'How to build webapps that scale',
+            articleDescription: 'This is the description for the post.',
+            tags: ['realworld', 'implementations'],
+          }}
         />
         <ArticlePreview
-          authorProfileLink="/profile/albert-pai"
-          authorProfileImageUrl="http://i.imgur.com/N4VcUeJ.jpg"
-          authorName="Albert Pai"
-          publishDate="January 20th"
-          likeCount={32}
-          articleLink="/article/the-song-you"
-          articleTitle="The song you won't ever stop singing. No matter how hard you try."
-          articleDescription="This is the description for the post."
-          tags={['realworld', 'implementations']}
+          articlePreview={{
+            authorProfileLink: '/profile/albert-pai',
+            authorProfileImageUrl: 'http://i.imgur.com/N4VcUeJ.jpg',
+            authorName: 'Albert Pai',
+            publishDate: 'January 20th',
+            likeCount: 32,
+            articleLink: '/article/the-song-you',
+            articleTitle:
+              "The song you won't ever stop singing. No matter how hard you try.",
+            articleDescription: 'This is the description for the post.',
+            tags: ['realworld', 'implementations'],
+          }}
         />
         <Pagination pages={[1, 2]} activePage={1} />
       </div>


### PR DESCRIPTION
## 📌 이슈 링크
- close https://github.com/pagers-org/react-world/issues/47

<br/>

## 📖 작업 배경

- 홈 페이지 API 연동 전에 컴포넌트 기반으로 리팩토링을 먼저 진행합니다.

<br/>

## 🛠️ 구현 내용

- ArticlePreview 에 들어간 하위 요소들을 styled component 로 전부 작성합니다. 
- 기존 ArticlePreview 를 하위 컴포넌트들의 조합으로 리팩토링합니다. 
- 홈 화면에서 새로 작성한 ArticlePreview 를 사용하도록 합니다. (아직 API 연동 전)

<br/>

## 💡 참고사항

- Article 내부 엘리먼트가 많아서.. 분리하는데 공수가 상당히 많이 드는군요ㅠ 
- 향후 API 연동 쪽 구현할 때 쓸 Response 를 미리 선언해 두었는데, 이걸 컴포넌트 단에서 props 로 바로 받는게 일반적으로 지향하는 구현인지 모르겠네요. 별도의 모델 선언을 따로 하는게 맞는 방식이려나요?

<br/>

## 🖼️ 스크린샷

기존 ArticlePreview(최상단 하나) 와, styled component 기반으로 새로 작성한 ArticlePreview(하단 두 개)가 완전히 동일하게 렌더링이 되는 모습

<img width="1166" alt="스크린샷 2023-09-13 오후 11 01 13" src="https://github.com/pagers-org/react-world/assets/2222333/68d25384-bf27-400a-8ac2-90f08d5a6b11">

