### PR TITLE
feat(home): 홈 페이지에서 페이지를 변경할 때 그에 맞는 아티클 목록을 받아와 표시하도록 합니다.

### DIFF
--- a/apps/react-world/src/apis/article/ArticlePreviewService.ts
+++ b/apps/react-world/src/apis/article/ArticlePreviewService.ts
@@ -6,10 +6,10 @@ export const ARTICLE_PREVIEW_FETCH_LIMIT = 10;
 
 class ArticleService {
   static async fetchArticlePreviews(
-    pageNumber: number,
+    pageIndex: number,
   ): Promise<ArticlePreviewResponse> {
     try {
-      const calculatedOffset = (pageNumber - 1) * ARTICLE_PREVIEW_FETCH_LIMIT;
+      const calculatedOffset = pageIndex * ARTICLE_PREVIEW_FETCH_LIMIT;
       const offset = calculatedOffset >= 0 ? calculatedOffset : 0; // offset이 0보다 작으면 0으로 설정
 
       const response = await api.get('/articles', {

--- a/apps/react-world/src/components/home/HomeFeedContents.tsx
+++ b/apps/react-world/src/components/home/HomeFeedContents.tsx
@@ -19,7 +19,14 @@ const HomeFeedContents = () => {
         <div className="col-md-9">
           <HomeFeedTab activeFeed="global_feed" />
           {isLoading ? (
-            <span>Loading Articles...</span>
+            <span
+              style={{
+                display: 'inline-block',
+                padding: '15px',
+              }}
+            >
+              Loading Articles...
+            </span>
           ) : (
             <>
               {data?.articles?.map(articlePreview => (

--- a/apps/react-world/src/components/home/HomeFeedContents.tsx
+++ b/apps/react-world/src/components/home/HomeFeedContents.tsx
@@ -8,7 +8,7 @@ import { ARTICLE_PREVIEW_FETCH_LIMIT } from '../../apis/article/ArticlePreviewSe
 
 const HomeFeedContents = () => {
   // TODO: Zustand Store 에서 초기값을 지정하고, 이후 현재 페이지 정보를 가지도록 구현 필요
-  const { data, isLoading } = useArticlePreviewQuery(1);
+  const { data, isLoading } = useArticlePreviewQuery(0);
   const totalPageCount = data?.articlesCount
     ? data.articlesCount / ARTICLE_PREVIEW_FETCH_LIMIT
     : 0;

--- a/apps/react-world/src/components/home/HomeFeedContents.tsx
+++ b/apps/react-world/src/components/home/HomeFeedContents.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Container } from '../shared/Container';
 import ArticlePreview from './ArticlePreview';
 import PopularArticleTagList from './PopularArticleTagList';
@@ -7,10 +8,15 @@ import useArticlePreviewQuery from '../../quries/useArticlePreviewQuery';
 import { ARTICLE_PREVIEW_FETCH_LIMIT } from '../../apis/article/ArticlePreviewService';
 
 const HomeFeedContents = () => {
-  // TODO: Zustand Store 에서 초기값을 지정하고, 이후 현재 페이지 정보를 가지도록 구현 필요
-  const { data, isLoading } = useArticlePreviewQuery(0);
+  const [currentPageIndex, setCurrentPageIndex] = useState(0);
+  const { data, isLoading } = useArticlePreviewQuery(currentPageIndex);
+
+  const handlePageChange = (newPageIndex: number) => {
+    setCurrentPageIndex(newPageIndex);
+  };
+
   const totalPageCount = data?.articlesCount
-    ? data.articlesCount / ARTICLE_PREVIEW_FETCH_LIMIT
+    ? Math.ceil(data.articlesCount / ARTICLE_PREVIEW_FETCH_LIMIT)
     : 0;
 
   return (
@@ -35,7 +41,11 @@ const HomeFeedContents = () => {
                   articlePreview={articlePreview}
                 />
               ))}
-              <Pagination totalPages={totalPageCount} activePageIndex={0} />
+              <Pagination
+                totalPages={totalPageCount}
+                activePageIndex={currentPageIndex}
+                onPageChange={handlePageChange}
+              />
             </>
           )}
         </div>

--- a/apps/react-world/src/components/home/HomeFeedContents.tsx
+++ b/apps/react-world/src/components/home/HomeFeedContents.tsx
@@ -50,20 +50,18 @@ const HomeFeedContents = () => {
           )}
         </div>
 
-        {isLoading ? null : (
-          <PopularArticleTagList
-            tags={[
-              'programming',
-              'javascript',
-              'emberjs',
-              'angularjs',
-              'react',
-              'mean',
-              'node',
-              'rails',
-            ]}
-          />
-        )}
+        <PopularArticleTagList
+          tags={[
+            'programming',
+            'javascript',
+            'emberjs',
+            'angularjs',
+            'react',
+            'mean',
+            'node',
+            'rails',
+          ]}
+        />
       </div>
     </Container>
   );

--- a/apps/react-world/src/components/home/Pagination.tsx
+++ b/apps/react-world/src/components/home/Pagination.tsx
@@ -3,15 +3,31 @@ import { PaginationContainer, PageButton } from './Pagination.styled';
 interface PaginationProps {
   totalPages: number;
   activePageIndex: number;
+  onPageChange: (newPageIndex: number) => void;
 }
 
-const Pagination = ({ totalPages, activePageIndex }: PaginationProps) => {
+const Pagination = ({
+  totalPages,
+  activePageIndex,
+  onPageChange,
+}: PaginationProps) => {
   const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
+
+  const handlePageClick = (pageIndex: number) => {
+    if (pageIndex !== activePageIndex) {
+      onPageChange(pageIndex);
+    }
+  };
 
   return (
     <PaginationContainer>
       {pages.map((page, index) => (
-        <PageButton key={page} href="#" isActive={index === activePageIndex}>
+        <PageButton
+          key={page}
+          href="#"
+          isActive={index === activePageIndex}
+          onClick={() => handlePageClick(index)}
+        >
           {page}
         </PageButton>
       ))}


### PR DESCRIPTION
## 📌 이슈 링크
- close https://github.com/pagers-org/react-world/issues/47

<br/>

## 📖 작업 배경

- 앞 작업에서 실 데이터와 Pagination 을 연동하는 작업을 했고, 이어서 액션에 따른 갱신 처리를 합니다.

<br/>

## 🛠️ 구현 내용

- Pagination 에서 액션이 발생할 때 상위로 이벤트를 전달하도록 구현합니다.
- 홈 피드 컴포넌트에서 페이지 변경이 있을 때 새로 아티클 목록을 받아오도록 로직을 개선합니다.
- 사이드바를 아티클 로딩에 따라 노출 처리를 묶어뒀었는데, 향후 더 좋은 방향으로 개선하기 위해 로딩 상태와 엮지 않도록 변경했습니다.

<br/>

## 💡 참고사항

- #110 의 커밋이 포함된 체이닝 PR입니다.

<br/>

## 🖼️ 스크린샷

https://github.com/pagers-org/react-world/assets/2222333/11136708-afe6-47ca-972f-b434414443c0
