### PR TITLE
feat(home): 홈 페이지의 인기 아티클 태그 목록 실제 데이터를 조회 후 연동하도록 합니다.

### DIFF
--- a/apps/react-world/src/apis/article/PopularArticleTagService.ts
+++ b/apps/react-world/src/apis/article/PopularArticleTagService.ts
@@ -1,0 +1,19 @@
+import { isAxiosError } from 'axios';
+import { api } from '../apiInstances';
+import type { PopularArticleTagsResponse } from './PopularArticleTagService.types';
+
+class PopularArticleTagService {
+  static async fetchPopularArticleTags(): Promise<PopularArticleTagsResponse> {
+    try {
+      const response = await api.get('/tags');
+      return response.data;
+    } catch (error) {
+      if (isAxiosError(error) && error.response) {
+        throw error.response.data;
+      }
+      throw error;
+    }
+  }
+}
+
+export default PopularArticleTagService;

--- a/apps/react-world/src/apis/article/PopularArticleTagService.types.ts
+++ b/apps/react-world/src/apis/article/PopularArticleTagService.types.ts
@@ -1,0 +1,3 @@
+export interface PopularArticleTagsResponse {
+  tags: string[];
+}

--- a/apps/react-world/src/components/home/HomeFeedContents.tsx
+++ b/apps/react-world/src/components/home/HomeFeedContents.tsx
@@ -9,14 +9,15 @@ import { ARTICLE_PREVIEW_FETCH_LIMIT } from '../../apis/article/ArticlePreviewSe
 
 const HomeFeedContents = () => {
   const [currentPageIndex, setCurrentPageIndex] = useState(0);
-  const { data, isLoading } = useArticlePreviewQuery(currentPageIndex);
+  const { articlePreviews, isArticlePreviewsLoading } =
+    useArticlePreviewQuery(currentPageIndex);
 
   const handlePageChange = (newPageIndex: number) => {
     setCurrentPageIndex(newPageIndex);
   };
 
-  const totalPageCount = data?.articlesCount
-    ? Math.ceil(data.articlesCount / ARTICLE_PREVIEW_FETCH_LIMIT)
+  const totalPageCount = articlePreviews?.articlesCount
+    ? Math.ceil(articlePreviews.articlesCount / ARTICLE_PREVIEW_FETCH_LIMIT)
     : 0;
 
   return (
@@ -24,7 +25,7 @@ const HomeFeedContents = () => {
       <div className="row">
         <div className="col-md-9">
           <HomeFeedTab activeFeed="global_feed" />
-          {isLoading ? (
+          {isArticlePreviewsLoading ? (
             <span
               style={{
                 display: 'inline-block',
@@ -35,7 +36,7 @@ const HomeFeedContents = () => {
             </span>
           ) : (
             <>
-              {data?.articles?.map(articlePreview => (
+              {articlePreviews?.articles?.map(articlePreview => (
                 <ArticlePreview
                   key={articlePreview.slug}
                   articlePreview={articlePreview}

--- a/apps/react-world/src/components/home/HomeFeedContents.tsx
+++ b/apps/react-world/src/components/home/HomeFeedContents.tsx
@@ -6,12 +6,14 @@ import HomeFeedTab from './HomeFeedTab';
 import Pagination from './Pagination';
 import useArticlePreviewQuery from '../../quries/useArticlePreviewQuery';
 import { ARTICLE_PREVIEW_FETCH_LIMIT } from '../../apis/article/ArticlePreviewService';
+import usePopularArticleTagsQuery from '../../quries/usePopularArticleTagsQuery';
 
 const HomeFeedContents = () => {
   const [currentPageIndex, setCurrentPageIndex] = useState(0);
   const { articlePreviews, isArticlePreviewsLoading } =
     useArticlePreviewQuery(currentPageIndex);
-
+  const { popularArticleTags, isPopularArticleTagsLoading } =
+    usePopularArticleTagsQuery();
   const handlePageChange = (newPageIndex: number) => {
     setCurrentPageIndex(newPageIndex);
   };
@@ -50,19 +52,9 @@ const HomeFeedContents = () => {
             </>
           )}
         </div>
-
-        <PopularArticleTagList
-          tags={[
-            'programming',
-            'javascript',
-            'emberjs',
-            'angularjs',
-            'react',
-            'mean',
-            'node',
-            'rails',
-          ]}
-        />
+        {isPopularArticleTagsLoading ? null : (
+          <PopularArticleTagList tags={popularArticleTags?.tags ?? []} />
+        )}
       </div>
     </Container>
   );

--- a/apps/react-world/src/quries/useArticlePreviewQuery.ts
+++ b/apps/react-world/src/quries/useArticlePreviewQuery.ts
@@ -5,10 +5,15 @@ export const ARTICLE_PREVIEW_CACHE_KEY = '@article/preview';
 
 const useArticlePreviewQuery = (pageNumber: number) => {
   ArticlePreviewService;
-  return useQuery(
+  const queryResult = useQuery(
     [ARTICLE_PREVIEW_CACHE_KEY, pageNumber], // 페이지 번호를 조합해 QueryKey 지정
     () => ArticlePreviewService.fetchArticlePreviews(pageNumber),
   );
+
+  return {
+    articlePreviews: queryResult.data,
+    isArticlePreviewsLoading: queryResult.isLoading,
+  };
 };
 
 export default useArticlePreviewQuery;

--- a/apps/react-world/src/quries/usePopularArticleTagsQuery.ts
+++ b/apps/react-world/src/quries/usePopularArticleTagsQuery.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import PopularArticleTagService from '../apis/article/PopularArticleTagService';
+
+export const POPULAR_ARTICLE_TAG_CACHE_KEY = '@article/popular_tags';
+
+const usePopularArticleTagsQuery = () => {
+  PopularArticleTagService;
+  const queryResult = useQuery([POPULAR_ARTICLE_TAG_CACHE_KEY], () =>
+    PopularArticleTagService.fetchPopularArticleTags(),
+  );
+
+  return {
+    popularArticleTags: queryResult.data,
+    isPopularArticleTagsLoading: queryResult.isLoading,
+  };
+};
+
+export default usePopularArticleTagsQuery;


### PR DESCRIPTION
## 📌 이슈 링크
- close https://github.com/pagers-org/react-world/issues/47

<br/>

## 📖 작업 배경

- '인기 아티클 태그 목록 조회'를 위한 서비스와 useQuery 를 작성합니다. 
- 홈 피드 컨텐츠 쪽에서 useQuery 를 두 개 사용해야 해서, 아티클 프리뷰 쪽과 인기 아티클 태그 목록의 useQuery 의 반환값에서 좀 더 구체적인 네이밍을 사용하도록 합니다.
- 홈 화면에서 실제 데이터를 불러와 연동하도록 합니다.

<br/>

## 🛠️ 구현 내용

- ㅇㅇPagination 에서 액션이 발생할 때 상위로 이벤트를 전달하도록 구현합니다.
- 홈 피드 컴포넌트에서 페이지 변경이 있을 때 새로 아티클 목록을 받아오도록 로직을 개선합니다.
- 사이드바를 아티클 로딩에 따라 노출 처리를 묶어뒀었는데, 향후 더 좋은 방향으로 개선하기 위해 로딩 상태와 엮지 않도록 변경했습니다.

<br/>

## 💡 참고사항

- #111 의 커밋이 포함된 체이닝 PR입니다.

<br/>

## 🖼️ 스크린샷

https://github.com/pagers-org/react-world/assets/2222333/11136708-afe6-47ca-972f-b434414443c0
