### PR TITLE
Input 공용 컴포넌트를 추가합니다.

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,12 +8,13 @@
     ".": "./src/index.ts"
   },
   "devDependencies": {
-    "@packages/ts-config": "*",
     "@packages/tailwindcss-config": "*",
+    "@packages/ts-config": "*",
     "react": "^18.2.0",
     "tailwindcss": "^3.3.3",
     "ts-pattern": "^5.0.5",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "tailwind-merge": "^1.14.0"
   },
   "dependencies": {
     "@vanilla-extract/css": "^1.13.0",

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -1,7 +1,14 @@
-import { forwardRef, HTMLAttributes, ReactNode } from "react";
-import { getColorStyle, getStartIcon } from "./util";
+import { ButtonHTMLAttributes, forwardRef, ReactNode } from "react";
+import {
+  getColorStyle,
+  getDisabledStyle,
+  getStartIcon,
+  getWidthStyle,
+} from "./util";
 import { sizeStyle } from "./style";
-export interface ButtonProps extends HTMLAttributes<HTMLButtonElement> {
+import { twMerge } from "tailwind-merge";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: ReactNode;
   icon?: {
     start: ReactNode;
@@ -9,6 +16,7 @@ export interface ButtonProps extends HTMLAttributes<HTMLButtonElement> {
   variant: "outlined" | "fill";
   color: "primary" | "gray" | "error";
   size: "s" | "m" | "lg";
+  fullWidth?: boolean;
 }
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
@@ -19,15 +27,27 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       variant = "outlined",
       size = "m",
       icon,
+      fullWidth = false,
+      className,
+      disabled = false,
+      ...rest
     }: ButtonProps,
     ref
   ) => {
     const colorStyle = getColorStyle({ color, variant });
     const startIcon = getStartIcon({ icon });
+    const widthStyle = getWidthStyle(fullWidth);
+    const disabledStyle = getDisabledStyle(disabled);
     return (
       <button
-        className={`flex items-center gap-4 ${sizeStyle[size]} ${colorStyle}`}
+        className={twMerge(
+          `flex items-center gap-4 w-fit cursor-pointer ${sizeStyle[size]} ${colorStyle} ${widthStyle}`,
+          disabledStyle,
+          className
+        )}
         ref={ref}
+        disabled={disabled}
+        {...rest}
       >
         {startIcon} {children}
       </button>

--- a/packages/ui/src/components/Button/util.ts
+++ b/packages/ui/src/components/Button/util.ts
@@ -22,3 +22,9 @@ export const getStartIcon = ({ icon }: Pick<ButtonProps, "icon">) => {
   }
   return icon.start;
 };
+
+export const getWidthStyle = (fullWidth: boolean) =>
+  fullWidth ? "w-full" : "w-fit";
+
+export const getDisabledStyle = (disabled: boolean) =>
+  disabled ? "hover:bg-[] hover:border-[] opacity-50 cursor-default" : "";

--- a/packages/ui/src/components/Input/Input.tsx
+++ b/packages/ui/src/components/Input/Input.tsx
@@ -1,0 +1,36 @@
+import { HTMLAttributes, forwardRef } from "react";
+
+interface InputProps
+  extends Omit<HTMLAttributes<HTMLInputElement>, "onChange"> {
+  size?: "m" | "lg";
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>, value: string) => void;
+}
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ size = "m", value = "", onChange, ...rest }, ref) => {
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      onChange?.(e, value);
+    };
+
+    return (
+      <input
+        value={value}
+        {...rest}
+        onChange={handleChange}
+        ref={ref}
+        className={`placeholder:text-gray-500 text-gray-600 border outline-none border-black/15 focus-within:border-blue-400 ${style.size[size]}`}
+      />
+    );
+  }
+);
+
+export default Input;
+
+const style = {
+  size: {
+    m: "py-[0.5rem] px-[0.75rem] text-[1rem] rounded-[0.25rem]",
+    lg: "py-[0.75rem] px-[1.5rem] text-[1.25rem] rounded-[0.3rem]",
+  },
+};

--- a/packages/ui/src/components/Input/Input.tsx
+++ b/packages/ui/src/components/Input/Input.tsx
@@ -20,7 +20,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         {...rest}
         onChange={handleChange}
         ref={ref}
-        className={`placeholder:text-gray-500 text-gray-600 border outline-none border-black/15 focus-within:border-blue-400 ${style.size[size]}`}
+        className={`w-full placeholder:text-gray-500 text-gray-600 border outline-none border-black/15 focus-within:border-blue-400 ${style.size[size]}`}
       />
     );
   }

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,6 +1,7 @@
 import Avatar from "./Avatar/Avatar";
 import Button from "./Button/Button";
+import Input from "./Input/Input";
 import Tabs from "./Tabs/Tabs";
 import Tag from "./Tag/Tag";
 
-export { Button, Tag, Tabs, Avatar };
+export { Button, Tag, Tabs, Avatar, Input };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6321,6 +6321,13 @@ react-dom@18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-error-boundary@^4.0.11:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.11.tgz#36bf44de7746714725a814630282fee83a7c9a1c"
+  integrity sha512-U13ul67aP5DOSPNSCWQ/eO0AQEYzEFkVljULQIjMV0KlffTAhxuDoBKdO0pb/JZ8mDhMKFZ9NZi0BmLGUiNphw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-icons@^4.11.0:
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.11.0.tgz#4b0e31c9bfc919608095cc429c4f1846f4d66c65"
@@ -7049,6 +7056,11 @@ synckit@0.8.5:
   dependencies:
     "@pkgr/utils" "^2.3.1"
     tslib "^2.5.0"
+
+tailwind-merge@^1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-1.14.0.tgz#e677f55d864edc6794562c63f5001f45093cdb8b"
+  integrity sha512-3mFKyCo/MBcgyOTlrY8T7odzZFx+w+qKSMAmdFzRvqBfLlSigU6TZnlFHK0lkMwj9Bj8OYU+9yW9lmGuS0QEnQ==
 
 tailwindcss@^3.3.3:
   version "3.3.3"


### PR DESCRIPTION
## 📖 작업 배경

- 공통적으로 쓰이는 Input 컴포넌트를 package/ui 레포지토리에 추가

<br/>

## 🛠️ 구현 내용

- size `m`, `lg`을 분기로 가지는 디자인 시스템 컴포넌트 구현

<br/>

## 💡 참고사항

- fullWidth를 props를 뚫으면서 Button 컴포넌트에도 추가
- tailwind-merge 패키지 추가
