### PR TITLE
feat : 임시로 로그인 상태를 구분합니다

### DIFF
--- a/apps/web/app/(articles)/_components/article-comment.tsx
+++ b/apps/web/app/(articles)/_components/article-comment.tsx
@@ -31,25 +31,6 @@ export function ArticleComment(): JSX.Element {
             <span className="date-posted">Dec 29th</span>
           </div>
         </div>
-
-        <div className="card">
-          <div className="card-block">
-            <p className="card-text">With supporting text below as a natural lead-in to additional content.</p>
-          </div>
-          <div className="card-footer">
-            <a className="comment-author" href="/profile/author">
-              <img alt="" className="comment-author-img" src="http://i.imgur.com/Qr71crq.jpg" />
-            </a>
-            &nbsp;
-            <a className="comment-author" href="/profile/jacob-schmidt">
-              Jacob Schmidt
-            </a>
-            <span className="date-posted">Dec 29th</span>
-            <span className="mod-options">
-              <i className="ion-trash-a" />
-            </span>
-          </div>
-        </div>
       </div>
     </div>
   );

--- a/apps/web/app/(articles)/_components/article-detail.tsx
+++ b/apps/web/app/(articles)/_components/article-detail.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useGetArticle } from "../_hooks/use-get-article";
 import { ArticleComment } from "./article-comment";
 import ArticleBanner from "./article-banner";
@@ -13,6 +14,8 @@ interface ArticleDetailProps {
 export function ArticleDetail({ slug }: ArticleDetailProps): JSX.Element {
   const { data } = useGetArticle(slug);
 
+  const isLogin = false;
+
   return (
     <div className="article-page">
       {data ? (
@@ -21,7 +24,18 @@ export function ArticleDetail({ slug }: ArticleDetailProps): JSX.Element {
           <div className="container page">
             <ArticleContent article={data} />
             <ArticleAction article={data} />
-            <ArticleComment />
+
+            {/* TODO : 로그인 구현 후 코멘트 상태 만들기 */}
+            {isLogin ? (
+              <ArticleComment />
+            ) : (
+              <div>
+                <Link href="/login">Sign in&nbsp;</Link>
+                or&nbsp;
+                <Link href="/register">sign up&nbsp;</Link>
+                to add comments on this article.
+              </div>
+            )}
           </div>
         </>
       ) : null}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,7 +1,19 @@
 const { createVanillaExtractPlugin } = require("@vanilla-extract/next-plugin");
 const withVanillaExtract = createVanillaExtractPlugin();
 
-const nextConfig = { reactStrictMode: true, transpilePackages: ["ui"] };
+const nextConfig = {
+  reactStrictMode: true,
+  transpilePackages: ["ui"],
+  async redirects() {
+    return [
+      {
+        source: "/",
+        destination: "/1",
+        permanent: true,
+      },
+    ];
+  },
+};
 
 module.exports = {};
 


### PR DESCRIPTION
## 📌 이슈 링크
- close #


<br/>

## 📖 작업 배경

- 로그인 작업 전 상세 페이지 코멘트에 대해 임시 로그인 상태를 만들어둡니다.

<br/>

## 🛠️ 구현 내용

- 비로그인 코멘트 노출 로직 추가
- 기본 라우트에 페이지네이션을 위한 번호를 붙입니다.

<br/>

## 💡 참고사항

-

<br/>

## 🖼️ 스크린샷

-

<br/>