### PR TITLE
feat: Home 페이지의 태그 클릭 시 해당 태그가 걸린 피드를 노출합니다.

### DIFF
--- a/app/(home)/@feed/(feed)/@popular/page.tsx
+++ b/app/(home)/@feed/(feed)/@popular/page.tsx
@@ -1,0 +1,23 @@
+import { Feed } from "components/(home)/@feed/feed";
+import { ARTICLES_PER_PAGE, INITIAL_PAGE } from "constants/articles";
+import { articleRepository } from "repositories/article";
+
+type Props = {
+  searchParams: Record<string, string>;
+};
+
+export const runtime = "edge";
+
+const PopularPage = async ({ searchParams: { page, tag } }: Props) => {
+  const currentPage = Number(page) || INITIAL_PAGE;
+
+  const { articles, articlesCount } = await articleRepository.findAll({
+    offset: (currentPage - 1) * ARTICLES_PER_PAGE,
+    limit: ARTICLES_PER_PAGE,
+    tag,
+  });
+
+  return <Feed articles={articles} total={articlesCount} />;
+};
+
+export default PopularPage;

--- a/app/(home)/@feed/(feed)/layout.tsx
+++ b/app/(home)/@feed/(feed)/layout.tsx
@@ -1,27 +1,47 @@
+"use client";
+
 import type { PropsWithChildren, ReactNode } from "react";
 
 import { Tabs } from "components/shared/ui/tabs";
+import { useQueryParams } from "hooks/use-query-params";
 
 const enum FeedType {
   GLOBAL = "global",
   FOLLOWING = "following",
+  POPULAR = "popular",
 }
 
 type Props = {
   global: ReactNode;
   following: ReactNode;
+  popular: ReactNode;
 };
 
-const FeedLayout = ({ global, following }: PropsWithChildren<Props>) => {
+const FeedLayout = ({ global, following, popular }: PropsWithChildren<Props>) => {
+  const {
+    query: { tag },
+    remove,
+  } = useQueryParams<{ tag: string }>();
+
+  const value = tag ? FeedType.POPULAR : undefined;
+
+  const handleChange = (value: string) => {
+    if (value !== FeedType.POPULAR) {
+      remove("tag");
+    }
+  };
+
   return (
-    <Tabs.Root defaultValue={FeedType.GLOBAL}>
+    <Tabs.Root defaultValue={FeedType.GLOBAL} value={value} onValueChange={handleChange}>
       <Tabs.List>
         <Tabs.Trigger value={FeedType.FOLLOWING}>Following Feed</Tabs.Trigger>
         <Tabs.Trigger value={FeedType.GLOBAL}>Global Feed</Tabs.Trigger>
+        {tag ? <Tabs.Trigger value={FeedType.POPULAR}># {tag}</Tabs.Trigger> : null}
       </Tabs.List>
 
       <Tabs.Content value={FeedType.FOLLOWING}>{following}</Tabs.Content>
       <Tabs.Content value={FeedType.GLOBAL}>{global}</Tabs.Content>
+      <Tabs.Content value={FeedType.POPULAR}>{popular}</Tabs.Content>
     </Tabs.Root>
   );
 };

--- a/app/(home)/@tags/(tags)/page.tsx
+++ b/app/(home)/@tags/(tags)/page.tsx
@@ -1,4 +1,4 @@
-import { Tags } from "components/shared/ui/tags";
+import { ArticleTags } from "components/(home)/@tags/article-tags/article-tags";
 import { tagRepository } from "repositories/tag";
 
 export const runtime = "edge";
@@ -6,15 +6,7 @@ export const runtime = "edge";
 const TagsPage = async () => {
   const { tags } = await tagRepository.findAll();
 
-  return (
-    <Tags.Root as="div">
-      {tags.map((tag) => (
-        <Tags.Item key={tag} as="a">
-          {tag}
-        </Tags.Item>
-      ))}
-    </Tags.Root>
-  );
+  return <ArticleTags tags={tags} />;
 };
 
 export default TagsPage;

--- a/components/(home)/@tags/article-tags/article-tags.tsx
+++ b/components/(home)/@tags/article-tags/article-tags.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { Tags } from "components/shared/ui/tags";
+import { INITIAL_PAGE } from "constants/articles";
+import { useQueryParams } from "hooks/use-query-params";
+
+type Props = {
+  tags: string[];
+};
+
+export const ArticleTags = ({ tags }: Props) => {
+  const { append } = useQueryParams();
+
+  return (
+    <Tags.Root as="div">
+      {tags.map((tag) => (
+        <Tags.Item key={tag} onClick={() => append({ tag, page: INITIAL_PAGE })}>
+          {tag}
+        </Tags.Item>
+      ))}
+    </Tags.Root>
+  );
+};

--- a/components/shared/ui/tabs/root.tsx
+++ b/components/shared/ui/tabs/root.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { createContext, useState, type PropsWithChildren } from "react";
+import { createContext, useState, type PropsWithChildren, useEffect } from "react";
 
 type Props = {
   defaultValue: string;
+  value?: string;
+  onValueChange?: (value: string) => void;
 };
 
 type TabsContextValue = {
@@ -13,15 +15,27 @@ type TabsContextValue = {
 
 export const TabsContext = createContext<TabsContextValue | null>(null);
 
-export const Root = ({ children, defaultValue }: PropsWithChildren<Props>) => {
+export const Root = ({ children, defaultValue, value, onValueChange }: PropsWithChildren<Props>) => {
   const [currentValue, setCurrentValue] = useState<string>(defaultValue);
 
-  const move = (value: string) => setCurrentValue(value);
+  const move = (value: string) => {
+    onValueChange?.(value);
+    setCurrentValue(value);
+  };
 
-  const value: TabsContextValue = {
+  useEffect(() => {
+    if (!value) {
+      return;
+    }
+
+    move(value);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
+  const context: TabsContextValue = {
     currentValue,
     move,
   };
 
-  return <TabsContext.Provider value={value}>{children}</TabsContext.Provider>;
+  return <TabsContext.Provider value={context}>{children}</TabsContext.Provider>;
 };

--- a/components/shared/ui/tags/root.tsx
+++ b/components/shared/ui/tags/root.tsx
@@ -13,7 +13,7 @@ const Root = <T extends ElementType = "ul">({ children, className, as, ...rest }
   const Component = as ?? "ul";
 
   return (
-    <Component ref={ref} {...rest} className={clsx("flex flex-wrap", className)}>
+    <Component ref={ref} {...rest} className={clsx("flex list-none flex-wrap", className)}>
       {children}
     </Component>
   );

--- a/hooks/use-query-params.ts
+++ b/hooks/use-query-params.ts
@@ -1,32 +1,41 @@
 import type { ReadonlyURLSearchParams } from "next/navigation";
-import { useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 import { useMemo } from "react";
 
 import { serializeQuery } from "lib/query";
+import { omit } from "utils/object";
 
 type Query = Record<string, string | number>;
 
 export const useQueryParams = <T extends Query = Query>() => {
   const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
 
   const query = useMemo(() => toQuery(searchParams), [searchParams]);
 
   const set = (incoming: Query) => {
-    router.push(serializeQuery(incoming));
+    router.push(join(pathname, serializeQuery(incoming)));
   };
 
   const append = (incoming: Query) => {
-    router.replace(serializeQuery({ ...query, ...incoming }), { scroll: false });
+    router.replace(join(pathname, serializeQuery({ ...query, ...incoming })), { scroll: false });
+  };
+
+  const remove = (...keys: string[]) => {
+    router.replace(join(pathname, serializeQuery(omit(query, keys))), { scroll: false });
   };
 
   return {
     query: query as Partial<T>,
     set,
     append,
+    remove,
   };
 };
+
+const join = (...args: string[]) => args.join("");
 
 const toQuery = (params: ReadonlyURLSearchParams) => {
   const query: Query = {};

--- a/utils/object.ts
+++ b/utils/object.ts
@@ -1,0 +1,11 @@
+import type { ObjectType } from "types/utilities";
+
+export const omit = <T extends ObjectType, K extends keyof T>(obj: T, keys: K[]): Omit<T, K> => {
+  const copied = { ...obj };
+
+  for (const key of keys) {
+    delete copied[key];
+  }
+
+  return copied as Omit<T, K>;
+};


### PR DESCRIPTION
## 📌 이슈 링크
- close #


<br/>

## 📖 작업 배경

- Home 페이지의 태그 클릭 시 해당 태그가 걸린 피드를 노출하는 기능을 구현했습니다.

<br/>

## 🛠️ 구현 내용

- 특정 query string을 제거하는 기능 구현을 위해, omit 유틸리티 함수를 구현했습니다.
- tag query string이 있는 경우 Popular 유형의 탭으로 전환하고, 다른 탭으로 이동 시 tag query string을 제거합니다.

<br/>

## 💡 참고사항

-

<br/>

## 🖼️ 스크린샷

https://github.com/pagers-org/react-world/assets/52942566/0f7ce1ca-b879-462b-b7c9-d3d5322222cf



<br/>