### PR TITLE
feat(article): 아티클 상세화면에 진입 시 실제 아티클 댓글 데이터를 받아 렌더링하도록 합니다.

### DIFF
--- a/apps/react-world/src/apis/article/ArticleService.ts
+++ b/apps/react-world/src/apis/article/ArticleService.ts
@@ -1,8 +1,10 @@
 import { isAxiosError } from 'axios';
-import { api } from '../apiInstances';
+import { api } from '@apis/apiInstances';
 import type {
   ArticleDetailResponse,
   ArticleDetailErrorResponse,
+  ArticleCommentsResponse,
+  ArticleCommentsErrorResponse,
 } from './ArticleService.types';
 
 class ArticleService {
@@ -16,6 +18,22 @@ class ArticleService {
       if (isAxiosError(error) && error.response) {
         console.error('Axios error occurred:', error.response.data);
         throw error.response.data as ArticleDetailErrorResponse;
+      }
+      console.error('An unexpected error occurred:', error);
+      throw error;
+    }
+  }
+
+  static async fetchArticleComments(
+    slug: string,
+  ): Promise<ArticleCommentsResponse> {
+    try {
+      const response = await api.get(`/articles/${slug}/comments`);
+      return response.data;
+    } catch (error) {
+      if (isAxiosError(error) && error.response) {
+        console.error('Axios error occurred:', error.response.data);
+        throw error.response.data as ArticleCommentsErrorResponse;
       }
       console.error('An unexpected error occurred:', error);
       throw error;

--- a/apps/react-world/src/apis/article/ArticleService.types.ts
+++ b/apps/react-world/src/apis/article/ArticleService.types.ts
@@ -1,5 +1,6 @@
 import type { ArticleAuthor } from './Article.types';
 
+// Article Detail
 export interface ArticleDetailData {
   slug: string;
   title: string;
@@ -18,6 +19,25 @@ export interface ArticleDetailResponse {
 }
 
 export interface ArticleDetailErrorResponse {
+  errors: {
+    body: string[];
+  };
+}
+
+// Article Comment
+export interface ArticleCommentData {
+  id: number;
+  createdAt: string;
+  updatedAt: string;
+  body: string;
+  author: ArticleAuthor;
+}
+
+export interface ArticleCommentsResponse {
+  comments: ArticleCommentData[];
+}
+
+export interface ArticleCommentsErrorResponse {
   errors: {
     body: string[];
   };

--- a/apps/react-world/src/components/article/ArticleComments.tsx
+++ b/apps/react-world/src/components/article/ArticleComments.tsx
@@ -1,4 +1,12 @@
-const ArticleComments = () => {
+import type { ArticleCommentData } from '@apis/article/ArticleService.types';
+
+interface ArticleCommentsProps {
+  comments: ArticleCommentData[];
+}
+
+const ArticleComments = (props: ArticleCommentsProps) => {
+  const { comments } = props;
+
   return (
     <div className="row">
       <div className="col-xs-12 col-md-8 offset-md-2">
@@ -10,6 +18,7 @@ const ArticleComments = () => {
             ></textarea>
           </div>
           <div className="card-footer">
+            {/* This will likely be the logged-in user's image */}
             <img
               src="http://i.imgur.com/Qr71crq.jpg"
               className="comment-author-img"
@@ -18,52 +27,39 @@ const ArticleComments = () => {
           </div>
         </form>
 
-        <div className="card">
-          <div className="card-block">
-            <p className="card-text">
-              With supporting text below as a natural lead-in to additional
-              content.
-            </p>
+        {comments.map(comment => (
+          <div key={comment.id} className="card">
+            <div className="card-block">
+              <p className="card-text">{comment.body}</p>
+            </div>
+            <div className="card-footer">
+              <a
+                href={`/profile/${comment.author.username}`}
+                className="comment-author"
+              >
+                <img
+                  src={comment.author.image}
+                  className="comment-author-img"
+                />
+              </a>
+              &nbsp;
+              <a
+                href={`/profile/${comment.author.username}`}
+                className="comment-author"
+              >
+                {comment.author.username}
+              </a>
+              <span className="date-posted">
+                {new Date(comment.createdAt).toDateString()}
+              </span>
+              {/* If the logged-in user has the right to delete this comment, display the delete button */}
+              {/* For now, I'm leaving it static but you'll likely need a condition */}
+              <span className="mod-options">
+                <i className="ion-trash-a"></i>
+              </span>
+            </div>
           </div>
-          <div className="card-footer">
-            <a href="/profile/author" className="comment-author">
-              <img
-                src="http://i.imgur.com/Qr71crq.jpg"
-                className="comment-author-img"
-              />
-            </a>
-            &nbsp;
-            <a href="/profile/jacob-schmidt" className="comment-author">
-              Jacob Schmidt
-            </a>
-            <span className="date-posted">Dec 29th</span>
-          </div>
-        </div>
-
-        <div className="card">
-          <div className="card-block">
-            <p className="card-text">
-              With supporting text below as a natural lead-in to additional
-              content.
-            </p>
-          </div>
-          <div className="card-footer">
-            <a href="/profile/author" className="comment-author">
-              <img
-                src="http://i.imgur.com/Qr71crq.jpg"
-                className="comment-author-img"
-              />
-            </a>
-            &nbsp;
-            <a href="/profile/jacob-schmidt" className="comment-author">
-              Jacob Schmidt
-            </a>
-            <span className="date-posted">Dec 29th</span>
-            <span className="mod-options">
-              <i className="ion-trash-a"></i>
-            </span>
-          </div>
-        </div>
+        ))}
       </div>
     </div>
   );

--- a/apps/react-world/src/components/article/ArticlePageContainer.tsx
+++ b/apps/react-world/src/components/article/ArticlePageContainer.tsx
@@ -4,6 +4,7 @@ import ArticleComments from './ArticleComments';
 import ArticleContents from './ArticleContents';
 import ArticleHeader from './ArticleHeader';
 import useArticleDetailQuery from '@quries/useArticleDetailQuery';
+import useArticleCommentsQuery from '@quries/useArticleCommentsQuery';
 
 interface ArticlePageContainerProps {
   articleSlug: string;
@@ -12,6 +13,7 @@ interface ArticlePageContainerProps {
 const ArticlePageContainer = (props: ArticlePageContainerProps) => {
   const { articleSlug } = props;
   const { articleDetail } = useArticleDetailQuery(articleSlug);
+  const { articleComments } = useArticleCommentsQuery(articleSlug);
 
   if (!articleDetail) {
     return null;
@@ -38,7 +40,7 @@ const ArticlePageContainer = (props: ArticlePageContainerProps) => {
           favorited={articleDetail.article.favorited}
           favoritesCount={articleDetail.article.favoritesCount}
         />
-        <ArticleComments />
+        <ArticleComments comments={articleComments?.comments || []} />
       </Container>
     </div>
   );

--- a/apps/react-world/src/quries/useArticleCommentsQuery.ts
+++ b/apps/react-world/src/quries/useArticleCommentsQuery.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import type { ArticleCommentsResponse } from '@apis/article/ArticleService.types';
+import ArticleService from '@apis/article/ArticleService';
+
+export const ARTICLE_COMMENTS_CACHE_KEY = '@article/comments';
+
+const useArticleCommentsQuery = (slug: string) => {
+  const queryResult = useQuery<ArticleCommentsResponse, Error>(
+    [ARTICLE_COMMENTS_CACHE_KEY, slug], // 슬러그를 조합해 QueryKey 지정
+    () => ArticleService.fetchArticleComments(slug),
+  );
+
+  return {
+    articleComments: queryResult.data,
+    isArticleCommentsLoading: queryResult.isLoading,
+  };
+};
+
+export default useArticleCommentsQuery;

--- a/apps/react-world/vite.config.ts
+++ b/apps/react-world/vite.config.ts
@@ -1,7 +1,5 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import { resolve } from 'path';
-import path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## 📌 이슈 링크
- close #85


<br/>

## 📖 작업 배경

- 이전 PR에 이어 아티클 상세화면 구현에 집중합니다.

<br/>

## 🛠️ 구현 내용

- 이전 PR 에서 vite.config.js 에 실수로 남겨둔 부분이 있어 잠수함 패치했습니다.
- 기존 ArticleService 에 아티클 댓글과 관련된 기능을 추가합니다.
- 아티클 댓글 목록을 불러오는 useQuery 를 작성합니다.
- 아티클 댓글 컴포넌트에서 실제 데이터를 받아 렌더링하도록 로직을 변경하고, 아티클 상세 컴포넌트에서 useQuery 를 통해 데이터를 받아와 댓글 컴포넌트에 props 로 데이터를 전달하도록 합니다.

## 💡 참고사항

- 댓글 등록 제거 기능을 만드려면 인증 구현이 먼저 되어야 할 것 같네요. 
- 이제는 정말 인증 기능을 만들 시기가 된 것 같습니다.

<br/>

## 🖼️ 스크린샷


https://github.com/pagers-org/react-world/assets/2222333/b4a7d976-0a54-4e00-b19d-86f19be150af




<br/>