### PR TITLE
회원가입 로직 기능을 추가합니다.

### DIFF
--- a/apps/web/app/(auth)/_api/index.ts
+++ b/apps/web/app/(auth)/_api/index.ts
@@ -1,0 +1,13 @@
+import { http } from "../../../lib/http";
+import { UserSchema } from "../_types";
+import type { UserType, RegisterReq, UserErrorType } from "../_types";
+
+export function register(req: RegisterReq): Promise<UserType | UserErrorType | undefined> {
+  return http.post({
+    url: "/users",
+    body: {
+      user: req,
+    },
+    schema: UserSchema,
+  });
+}

--- a/apps/web/app/(auth)/_component/error-message.tsx
+++ b/apps/web/app/(auth)/_component/error-message.tsx
@@ -1,0 +1,11 @@
+interface ErrorMessageProps {
+  message?: string;
+}
+
+export function ErrorMessage({ message }: ErrorMessageProps): JSX.Element {
+  return (
+    <ul className="error-messages">
+      <li>{message}</li>
+    </ul>
+  );
+}

--- a/apps/web/app/(auth)/_component/register-form.tsx
+++ b/apps/web/app/(auth)/_component/register-form.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import type { SubmitHandler } from "react-hook-form";
+import { useForm } from "react-hook-form";
+import { useRouter } from "next/navigation";
+import type { RegisterReq } from "../_types";
+import { useRegister } from "../_hooks/use-register";
+import { UserSchema, UserType } from "../_types";
+import { ErrorMessage } from "./error-message";
+
+export function RegisterForm(): JSX.Element {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setError,
+    resetField,
+  } = useForm<RegisterReq>();
+
+  const { mutate } = useRegister();
+
+  const router = useRouter();
+
+  const onSubmit: SubmitHandler<RegisterReq> = data => {
+    mutate(data, {
+      onSuccess: () => {
+        router.push("/login");
+      },
+      onError: () => {
+        setError("email", {
+          message: "email has already been taken",
+        });
+        setError("username", {
+          message: "username has already been taken",
+        });
+
+        resetField("password");
+      },
+    });
+  };
+
+  const isEmailValid = (email: string) => {
+    const emailPattern = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i;
+    return emailPattern.test(email);
+  };
+
+  return (
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <fieldset className="form-group">
+        <input
+          {...register("username", { required: "Username can't be blank" })}
+          className="form-control form-control-lg"
+          placeholder="Username"
+          type="text"
+        />
+      </fieldset>
+      {errors.username ? <ErrorMessage message={errors.username.message} /> : null}
+
+      <fieldset className="form-group">
+        <input
+          {...register("email", {
+            required: "Email can't be blank",
+            validate: email => isEmailValid(email) || "Invalid email format",
+          })}
+          className="form-control form-control-lg"
+          placeholder="Email"
+          type="text"
+        />
+      </fieldset>
+      {errors.email ? <ErrorMessage message={errors.email.message} /> : null}
+
+      <fieldset className="form-group">
+        <input
+          {...register("password", { required: "Password can't be blank" })}
+          className="form-control form-control-lg"
+          placeholder="Password"
+          type="password"
+        />
+      </fieldset>
+      {errors.password ? <ErrorMessage message={errors.password.message} /> : null}
+
+      <button className="btn btn-lg btn-primary pull-xs-right" type="submit">
+        Sign up
+      </button>
+    </form>
+  );
+}

--- a/apps/web/app/(auth)/_hooks/use-register.tsx
+++ b/apps/web/app/(auth)/_hooks/use-register.tsx
@@ -1,0 +1,9 @@
+import { useMutation } from "@tanstack/react-query";
+import type { RegisterReq } from "../_types";
+import { register } from "../_api";
+
+export function useRegister() {
+  return useMutation({
+    mutationFn: (req: RegisterReq) => register(req),
+  });
+}

--- a/apps/web/app/(auth)/_types/index.ts
+++ b/apps/web/app/(auth)/_types/index.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export interface RegisterReq {
+  username: string;
+  email: string;
+  password: string;
+}
+
+export const UserErrorsSchema = z.object({
+  errors: z.object({
+    email: z.array(z.string()),
+    username: z.array(z.string()),
+  }),
+});
+
+export const UserSchema = z.object({
+  user: z.object({
+    email: z.string(),
+    token: z.string(),
+    username: z.string(),
+    bio: z.string(),
+    image: z.string(),
+  }),
+});
+
+export type UserErrorType = z.infer<typeof UserErrorsSchema>;
+
+export type UserType = z.infer<typeof UserSchema>;

--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -1,3 +1,5 @@
+import { RegisterForm } from "../_component/register-form";
+
 export default function RegisterPage(): JSX.Element {
   return (
     <div className="auth-page">
@@ -9,24 +11,7 @@ export default function RegisterPage(): JSX.Element {
               <a href="/login">Have an account?</a>
             </p>
 
-            <ul className="error-messages">
-              <li>That email is already taken</li>
-            </ul>
-
-            <form>
-              <fieldset className="form-group">
-                <input className="form-control form-control-lg" placeholder="Username" type="text" />
-              </fieldset>
-              <fieldset className="form-group">
-                <input className="form-control form-control-lg" placeholder="Email" type="text" />
-              </fieldset>
-              <fieldset className="form-group">
-                <input className="form-control form-control-lg" placeholder="Password" type="password" />
-              </fieldset>
-              <button className="btn btn-lg btn-primary pull-xs-right" type="button">
-                Sign up
-              </button>
-            </form>
+            <RegisterForm />
           </div>
         </div>
       </div>

--- a/apps/web/lib/http.ts
+++ b/apps/web/lib/http.ts
@@ -1,5 +1,6 @@
 import type { z, ZodType } from "zod";
 import { ZodError } from "zod";
+import { UserErrorsSchema } from "../app/(auth)/_types";
 
 const HTTP_ERRORS = {
   BAD_REQUEST: "잘못된 요청: 요청이 잘못되었습니다.",
@@ -7,6 +8,7 @@ const HTTP_ERRORS = {
   FORBIDDEN: "금지됨 : 이 리소스에 액세스 권한이 없습니다.",
   NOT_FOUND: "찾을 수 없음: 요청한 리소스를 찾을 수 없습니다.",
   INTERNAL_SERVER_ERROR: "내부 서버 오류: 서버에서 오류가 발생했습니다.",
+  ALREADY_TOKEN: "토큰 : 이미 토큰이 있습니다.",
 };
 
 export const httpErrorHandler = (e: unknown, statusCode?: number): never => {
@@ -19,6 +21,8 @@ export const httpErrorHandler = (e: unknown, statusCode?: number): never => {
       throw new Error(HTTP_ERRORS.FORBIDDEN);
     case 404:
       throw new Error(HTTP_ERRORS.NOT_FOUND);
+    case 422:
+      throw new Error(HTTP_ERRORS.ALREADY_TOKEN);
     case 500:
       throw new Error(HTTP_ERRORS.INTERNAL_SERVER_ERROR);
     default:
@@ -46,23 +50,19 @@ export const buildUrl = (url: string): string => `${"https://api.realworld.io/ap
 
 export const http = {
   async get<Response>({ url, accessToken, schema }: { url: string; accessToken?: string; schema: ZodType<Response> }) {
-    try {
-      const headers = createHeaders(accessToken);
+    const headers = createHeaders(accessToken);
 
-      const res = await fetch(buildUrl(url), {
-        method: "GET",
-        headers,
-      });
+    const res = await fetch(buildUrl(url), {
+      method: "GET",
+      headers,
+    });
 
-      if (!res.ok) {
-        httpErrorHandler(new Error(`HTTP Error: ${res.statusText}`), res.status);
-      }
-
-      const obj: z.infer<typeof schema> = schema.parse(await res.json());
-      return obj;
-    } catch (e) {
-      httpErrorHandler(e);
+    if (!res.ok) {
+      httpErrorHandler(new Error(`HTTP Error: ${res.statusText}`), res.status);
     }
+
+    const obj = schema.parse(await res.json());
+    return obj;
   },
   async post<Request, Response>({
     url,
@@ -75,23 +75,19 @@ export const http = {
     schema: ZodType<Response>;
     body: Request;
   }) {
-    try {
-      const headers = createHeaders(accessToken);
+    const headers = createHeaders(accessToken);
 
-      const res = await fetch(buildUrl(url), {
-        method: "POST",
-        headers,
-        body: JSON.stringify(body),
-      });
+    const res = await fetch(buildUrl(url), {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
 
-      if (!res.ok) {
-        httpErrorHandler(new Error(`HTTP Error: ${res.statusText}`), res.status);
-      }
-
-      const obj: z.infer<typeof schema> = schema.parse(await res.json());
-      return obj;
-    } catch (e) {
-      httpErrorHandler(e);
+    if (!res.ok) {
+      httpErrorHandler(new Error(`HTTP Error: ${res.statusText}`), res.status);
     }
+
+    const obj = schema.parse(await res.json());
+    return obj;
   },
 };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-error-boundary": "^4.0.11",
+    "react-hook-form": "^7.46.1",
     "ui": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       react-error-boundary:
         specifier: ^4.0.11
         version: 4.0.11(react@18.2.0)
+      react-hook-form:
+        specifier: ^7.46.1
+        version: 7.46.1(react@18.2.0)
       ui:
         specifier: workspace:*
         version: link:../../packages/ui
@@ -4705,6 +4708,15 @@ packages:
       react: '>=16.13.1'
     dependencies:
       '@babel/runtime': 7.22.11
+      react: 18.2.0
+    dev: false
+
+  /react-hook-form@7.46.1(react@18.2.0):
+    resolution: {integrity: sha512-0GfI31LRTBd5tqbXMGXT1Rdsv3rnvy0FjEk8Gn9/4tp6+s77T7DPZuGEpBRXOauL+NhyGT5iaXzdIM2R6F/E+w==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18
+    dependencies:
       react: 18.2.0
     dev: false
 


### PR DESCRIPTION
## 📌 이슈 링크
- close #127 


<br/>

## 📖 작업 배경

- 아티클 상세 페이지에 필요한 댓글, 팔로잉 등을 관리하기 위해 회원가입 기능을 추가합니다.

<br/>

## 🛠️ 구현 내용

- 폼 관리를 위한 react-hook-form 추가
- 회원가입 api 추가
  - 회원가입 시 422 에러가 떨어져 정상적인 회원가입 플로우를 만들 수가 없어서 일단 회원 가입을 성공 시 로그인 페이지로 보내버립니다.
- 회원가입 폼 분리 및 validation 과 Required 에러 메시지 추가 (이메일 포멧 추가, 빈 칸 입력 제거)
- 에러 메시지를 인풋 하단으로 옮겨놨습니다 (기존 데모 페이지에서는 상단에 다 뭉쳐있더군요)

<br/>

## 💡 참고사항

- 궁금한 점이 있습니다. fetch 에서 throw error 를 던졌을때 react query 내 onError 콜백 인자로 받아서 처리를 하고 싶습니다. axios 를 사용했을 땐 콜백 인자의 Error 가 객체로 넘겨졌는데 지금은 throw new error를 해서 그런지 따로 잡히는게 없습니다. 
- 폼에서 에러를 처리하는것이 상당히 중요하므로(어떤 필드의 에러가 나는 지를 보여줘야해서..) 다른 분들은 어떻게 하셨는지 꼭 코멘트 남겨주세요.. 😭

<br/>

## 🖼️ 스크린샷

https://github.com/pagers-org/react-world/assets/54930877/be6616ac-e273-497f-ac7c-4a83c6a4cbbd



<br/>