### PR TITLE
feat: Articles/Profile 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "prettier-plugin-tailwindcss": "^0.5.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-ionicons": "^4.2.1",
     "tailwind-merge": "^1.14.0",
     "tailwindcss": "^3.3.3",
     "zod": "^3.22.2",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "autoprefixer": "^10.4.15",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
+    "dayjs": "^1.11.10",
     "eslint-plugin-tailwindcss": "^3.13.0",
     "immer": "^10.0.2",
     "next": "^13.4.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ specifiers:
   babel-jest: ^29.6.2
   class-variance-authority: ^0.7.0
   clsx: ^2.0.0
+  dayjs: ^1.11.10
   eslint: ^8.47.0
   eslint-config-next: ^13.4.16
   eslint-config-prettier: ^9.0.0
@@ -55,6 +56,7 @@ dependencies:
   autoprefixer: 10.4.15_postcss@8.4.29
   class-variance-authority: 0.7.0
   clsx: 2.0.0
+  dayjs: 1.11.10
   eslint-plugin-tailwindcss: 3.13.0_tailwindcss@3.3.3
   immer: 10.0.2
   next: 13.4.19_h6kuhl5org62hkozzbezqqrdtu
@@ -2133,6 +2135,10 @@ packages:
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
     dev: true
+
+  /dayjs/1.11.10:
+    resolution: {integrity: sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==}
+    dev: false
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,7 @@ specifiers:
   prettier-plugin-tailwindcss: ^0.5.4
   react: ^18.2.0
   react-dom: ^18.2.0
+  react-ionicons: ^4.2.1
   react-test-renderer: ^18.2.0
   tailwind-merge: ^1.14.0
   tailwindcss: ^3.3.3
@@ -62,6 +63,7 @@ dependencies:
   prettier-plugin-tailwindcss: 0.5.4_xpfwxcyzcsz3w5wn2imjtkkk7q
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
+  react-ionicons: 4.2.1
   tailwind-merge: 1.14.0
   tailwindcss: 3.3.3
   zod: 3.22.2
@@ -1668,6 +1670,10 @@ packages:
       is-shared-array-buffer: 1.0.2
     dev: true
 
+  /asap/2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+    dev: false
+
   /ast-types-flow/0.0.7:
     resolution: {integrity: sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==}
     dev: true
@@ -2057,6 +2063,11 @@ packages:
       is-what: 4.1.15
     dev: true
 
+  /core-js/1.2.7:
+    resolution: {integrity: sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==}
+    deprecated: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
+    dev: false
+
   /cosmiconfig/8.3.2_typescript@5.2.2:
     resolution: {integrity: sha512-/PvU3MjSLVKJMRHsL6GW+wHQ9RaJuMW6fnn56sXNy+kP1L8nI/SHk9F9giIA+dnfzjKNJAulRjOR/fi9kzGuNA==}
     engines: {node: '>=18'}
@@ -2300,6 +2311,12 @@ packages:
   /emoji-regex/9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
     dev: true
+
+  /encoding/0.1.13:
+    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
+    dependencies:
+      iconv-lite: 0.6.3
+    dev: false
 
   /enhanced-resolve/5.15.0:
     resolution: {integrity: sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==}
@@ -2872,6 +2889,18 @@ packages:
       bser: 2.1.1
     dev: true
 
+  /fbjs/0.8.18:
+    resolution: {integrity: sha512-EQaWFK+fEPSoibjNy8IxUtaFOMXcWsY0JaVrQoZR9zC8N2Ygf9iDITPWjUTVIax95b6I742JFLqASHfsag/vKA==}
+    dependencies:
+      core-js: 1.2.7
+      isomorphic-fetch: 2.2.1
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      promise: 7.3.1
+      setimmediate: 1.0.5
+      ua-parser-js: 0.7.36
+    dev: false
+
   /file-entry-cache/6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -3195,7 +3224,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
-    dev: true
 
   /ignore/5.2.4:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
@@ -3419,6 +3447,11 @@ packages:
       call-bind: 1.0.2
     dev: true
 
+  /is-stream/1.1.0:
+    resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /is-stream/2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
@@ -3486,6 +3519,13 @@ packages:
   /isexe/2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
+
+  /isomorphic-fetch/2.2.1:
+    resolution: {integrity: sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==}
+    dependencies:
+      node-fetch: 1.7.3
+      whatwg-fetch: 3.6.19
+    dev: false
 
   /istanbul-lib-coverage/3.2.0:
     resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
@@ -4377,6 +4417,13 @@ packages:
       - babel-plugin-macros
     dev: false
 
+  /node-fetch/1.7.3:
+    resolution: {integrity: sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==}
+    dependencies:
+      encoding: 0.1.13
+      is-stream: 1.1.0
+    dev: false
+
   /node-int64/0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
     dev: true
@@ -4832,6 +4879,12 @@ packages:
       react-is: 18.2.0
     dev: true
 
+  /promise/7.3.1:
+    resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
+    dependencies:
+      asap: 2.0.6
+    dev: false
+
   /prompts/2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -4839,6 +4892,13 @@ packages:
       kleur: 3.0.3
       sisteransi: 1.0.5
     dev: true
+
+  /prop-types/15.5.10:
+    resolution: {integrity: sha512-vCFzoUFaZkVNeFkhK1KbSq4cn97GDrpfBt9K2qLkGnPAEFhEv3M61Lk5t+B7c0QfMLWo0fPkowk/4SuXerh26Q==}
+    dependencies:
+      fbjs: 0.8.18
+      loose-envify: 1.4.0
+    dev: false
 
   /prop-types/15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -4872,6 +4932,17 @@ packages:
     dependencies:
       safe-buffer: 5.2.1
 
+  /react-dom/17.0.1_react@17.0.1:
+    resolution: {integrity: sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==}
+    peerDependencies:
+      react: 17.0.1
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react: 17.0.1
+      scheduler: 0.20.2
+    dev: false
+
   /react-dom/18.2.0_react@18.2.0:
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
     peerDependencies:
@@ -4880,6 +4951,17 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+
+  /react-ionicons/4.2.1:
+    resolution: {integrity: sha512-/i6Sp35YF5bxtoDoAN/K6WOrvwDXDmYOYdkYd7dKT42ExSo0T79CB2Z3ejsWoOLxmZdgcXOBk8EKE/lbx89rEA==}
+    peerDependencies:
+      browserify-css: 0.12.0
+      styled-components: '>= 4'
+    dependencies:
+      prop-types: 15.5.10
+      react: 17.0.1
+      react-dom: 17.0.1_react@17.0.1
+    dev: false
 
   /react-is/16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -4913,6 +4995,14 @@ packages:
       react-shallow-renderer: 16.15.0_react@18.2.0
       scheduler: 0.23.0
     dev: true
+
+  /react/17.0.1:
+    resolution: {integrity: sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+    dev: false
 
   /react/18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
@@ -5079,7 +5169,6 @@ packages:
 
   /safer-buffer/2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-    dev: true
 
   /saxes/6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -5087,6 +5176,13 @@ packages:
     dependencies:
       xmlchars: 2.2.0
     dev: true
+
+  /scheduler/0.20.2:
+    resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+    dev: false
 
   /scheduler/0.23.0:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
@@ -5116,6 +5212,10 @@ packages:
     resolution: {integrity: sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==}
     dependencies:
       randombytes: 2.1.0
+
+  /setimmediate/1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+    dev: false
 
   /shebang-command/2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -5660,6 +5760,10 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  /ua-parser-js/0.7.36:
+    resolution: {integrity: sha512-CPPLoCts2p7D8VbybttE3P2ylv0OBZEAy7a12DsulIEcAiMtWJy+PBgMXgWDI80D5UwqE8oQPHYnk13tm38M2Q==}
+    dev: false
+
   /unbox-primitive/1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
     dependencies:
@@ -5795,6 +5899,10 @@ packages:
     dependencies:
       iconv-lite: 0.6.3
     dev: true
+
+  /whatwg-fetch/3.6.19:
+    resolution: {integrity: sha512-d67JP4dHSbm2TrpFj8AbO8DnL1JXL5J9u0Kq2xW6d0TFDbCA3Muhdt8orXC22utleTVj7Prqt82baN6RBvnEgw==}
+    dev: false
 
   /whatwg-mimetype/3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}

--- a/src/api/article.ts
+++ b/src/api/article.ts
@@ -2,6 +2,8 @@ import { ArticlePostRequestType, FeedResponseType } from '@/types/article';
 
 import { BASE_HEADER, BASE_URL } from '@/constants/auth';
 
+const accessToken = JSON.parse(window.localStorage.getItem('user'))?.token;
+
 const getGlobalFeed = async (
   headers: HeadersInit = {},
   options: RequestInit = {},
@@ -21,24 +23,22 @@ const getGlobalFeed = async (
 const getMyFeed = async (
   headers: HeadersInit = {},
   options: RequestInit = {},
-): Promise<FeedResponseType> => {
+): Promise<Response> => {
   return await fetch(`${BASE_URL}/articles/feed`, {
     ...options,
     method: 'get',
     headers: {
       ...BASE_HEADER,
       ...headers,
+      Authorization: `Bearer ${accessToken}`,
     },
-  })
-    .then((res) => res.json())
-    .catch((err) => console.error(err));
+  });
 };
 
 const postArticleRegister = async (
   request: ArticlePostRequestType,
   options: RequestInit = {},
 ): Promise<FeedResponseType> => {
-  const accessToken = JSON.parse(window.localStorage.getItem('user'))?.token;
   return await fetch(`${BASE_URL}/articles`, {
     ...options,
     method: 'post',

--- a/src/api/article.ts
+++ b/src/api/article.ts
@@ -1,4 +1,4 @@
-import { FeedResponseType } from '@/types/article';
+import { ArticlePostRequestType, FeedResponseType } from '@/types/article';
 
 import { BASE_HEADER, BASE_URL } from '@/constants/auth';
 
@@ -34,4 +34,22 @@ const getMyFeed = async (
     .catch((err) => console.error(err));
 };
 
-export { getGlobalFeed, getMyFeed };
+const postArticleRegister = async (
+  request: ArticlePostRequestType,
+  options: RequestInit = {},
+): Promise<FeedResponseType> => {
+  const accessToken = JSON.parse(window.localStorage.getItem('user'))?.token;
+  return await fetch(`${BASE_URL}/articles`, {
+    ...options,
+    method: 'post',
+    headers: {
+      ...BASE_HEADER,
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(request),
+  })
+    .then((res) => res.json())
+    .catch((err) => console.error(err));
+};
+
+export { getGlobalFeed, getMyFeed, postArticleRegister };

--- a/src/api/article.ts
+++ b/src/api/article.ts
@@ -87,10 +87,61 @@ const getAuthorArticle = async (
   });
 };
 
+const getArticleDetail = async (
+  slug: string,
+  headers: HeadersInit = {},
+  options: RequestInit = {},
+): Promise<Response> => {
+  return await fetch(`${BASE_URL}/articles/${slug}`, {
+    ...options,
+    method: 'get',
+    headers: {
+      ...BASE_HEADER,
+      ...headers,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+};
+
+const favoriteUser = async (
+  slug: string,
+  headers: HeadersInit = {},
+  options: RequestInit = {},
+): Promise<Response> => {
+  return await fetch(`${BASE_URL}/articles/${slug}/favorite`, {
+    ...options,
+    method: 'post',
+    headers: {
+      ...BASE_HEADER,
+      ...headers,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+};
+
+const unFavoriteUser = async (
+  slug: string,
+  headers: HeadersInit = {},
+  options: RequestInit = {},
+): Promise<Response> => {
+  return await fetch(`${BASE_URL}/articles/${slug}/favorite`, {
+    ...options,
+    method: 'delete',
+    headers: {
+      ...BASE_HEADER,
+      ...headers,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+};
+
 export {
   getGlobalFeed,
   getMyFeed,
   postArticleRegister,
   getFavorited,
   getAuthorArticle,
+  favoriteUser,
+  unFavoriteUser,
+  getArticleDetail,
 };

--- a/src/api/article.ts
+++ b/src/api/article.ts
@@ -1,0 +1,21 @@
+import { GlobalFeedResponseType } from '@/types/article';
+
+import { BASE_HEADER, BASE_URL } from '@/constants/auth';
+
+const getGlobalFeed = async (
+  headers: HeadersInit = {},
+  options: RequestInit = {},
+): Promise<GlobalFeedResponseType> => {
+  return await fetch(`${BASE_URL}/articles`, {
+    ...options,
+    method: 'get',
+    headers: {
+      ...BASE_HEADER,
+      ...headers,
+    },
+  })
+    .then((res) => res.json())
+    .catch((err) => console.error(err));
+};
+
+export { getGlobalFeed };

--- a/src/api/article.ts
+++ b/src/api/article.ts
@@ -1,11 +1,11 @@
-import { GlobalFeedResponseType } from '@/types/article';
+import { FeedResponseType } from '@/types/article';
 
 import { BASE_HEADER, BASE_URL } from '@/constants/auth';
 
 const getGlobalFeed = async (
   headers: HeadersInit = {},
   options: RequestInit = {},
-): Promise<GlobalFeedResponseType> => {
+): Promise<FeedResponseType> => {
   return await fetch(`${BASE_URL}/articles`, {
     ...options,
     method: 'get',
@@ -18,4 +18,20 @@ const getGlobalFeed = async (
     .catch((err) => console.error(err));
 };
 
-export { getGlobalFeed };
+const getMyFeed = async (
+  headers: HeadersInit = {},
+  options: RequestInit = {},
+): Promise<FeedResponseType> => {
+  return await fetch(`${BASE_URL}/articles/feed`, {
+    ...options,
+    method: 'get',
+    headers: {
+      ...BASE_HEADER,
+      ...headers,
+    },
+  })
+    .then((res) => res.json())
+    .catch((err) => console.error(err));
+};
+
+export { getGlobalFeed, getMyFeed };

--- a/src/api/article.ts
+++ b/src/api/article.ts
@@ -52,4 +52,45 @@ const postArticleRegister = async (
     .catch((err) => console.error(err));
 };
 
-export { getGlobalFeed, getMyFeed, postArticleRegister };
+const getFavorited = async (
+  slug: string,
+  headers: HeadersInit = {},
+  options: RequestInit = {},
+): Promise<Response> => {
+  return await fetch(
+    `${BASE_URL}/articles?favorited=${slug}&limit=5&offset=0`,
+    {
+      ...options,
+      method: 'get',
+      headers: {
+        ...BASE_HEADER,
+        ...headers,
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  );
+};
+
+const getAuthorArticle = async (
+  author: string,
+  headers: HeadersInit = {},
+  options: RequestInit = {},
+): Promise<Response> => {
+  return await fetch(`${BASE_URL}/articles?author=${author}&limit=5&offset=0`, {
+    ...options,
+    method: 'get',
+    headers: {
+      ...BASE_HEADER,
+      ...headers,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+};
+
+export {
+  getGlobalFeed,
+  getMyFeed,
+  postArticleRegister,
+  getFavorited,
+  getAuthorArticle,
+};

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -2,8 +2,8 @@
 import {
   LoginPostRequestType,
   RegisterPostRequestType,
-  UpdatePutRequestType,
-  UsersResponseType,
+  UpdateUserType,
+  UserType,
 } from '@/types/auth';
 
 import { BASE_HEADER, BASE_URL } from '@/constants/auth';
@@ -12,7 +12,7 @@ import { BASE_HEADER, BASE_URL } from '@/constants/auth';
 const postUserLogin = async (
   request: LoginPostRequestType,
   options: RequestInit = {},
-): Promise<UsersResponseType> => {
+): Promise<UserType> => {
   return await fetch(`${BASE_URL}/users/login`, {
     ...options,
     method: 'post',
@@ -29,7 +29,7 @@ const postUserLogin = async (
 const postUserRegister = async (
   request: RegisterPostRequestType,
   options: RequestInit = {},
-): Promise<UsersResponseType> => {
+): Promise<UserType> => {
   return await fetch(`${BASE_URL}/users`, {
     ...options,
     method: 'post',
@@ -43,20 +43,17 @@ const postUserRegister = async (
 };
 
 // Updated user information for current user
-const putCurrentUser = async (
-  payload: UpdatePutRequestType,
+const updateUser = async (
+  payload: UpdateUserType,
   headers: HeadersInit = {},
   options: RequestInit = {},
-): Promise<UsersResponseType | string> => {
-  const accessToken = getCookie(COOKIE_ACCESS_TOKEN_KEY);
-
+): Promise<UserType> => {
   return await fetch(`${BASE_URL}/user`, {
     ...options,
     method: 'put',
     headers: {
       ...BASE_HEADER,
       ...headers,
-      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify(payload),
   })
@@ -72,7 +69,7 @@ const putCurrentUser = async (
 const getCurrentUser = async (
   headers: HeadersInit = {},
   options: RequestInit = {},
-): Promise<UsersResponseType> => {
+): Promise<UserType> => {
   return await fetch(`${BASE_URL}/user`, {
     ...options,
     method: 'get',
@@ -85,4 +82,4 @@ const getCurrentUser = async (
     .catch((err) => console.error(err));
 };
 
-export { postUserRegister, postUserLogin, putCurrentUser, getCurrentUser };
+export { postUserRegister, postUserLogin, updateUser, getCurrentUser };

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -8,6 +8,8 @@ import {
 
 import { BASE_HEADER, BASE_URL } from '@/constants/auth';
 
+const accessToken = JSON.parse(window.localStorage.getItem('user'))?.token;
+
 // Login for existing user
 const postUserLogin = async (
   request: LoginPostRequestType,
@@ -54,6 +56,7 @@ const updateUser = async (
     headers: {
       ...BASE_HEADER,
       ...headers,
+      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify(payload),
   })

--- a/src/api/comment.ts
+++ b/src/api/comment.ts
@@ -1,0 +1,54 @@
+import { BASE_HEADER, BASE_URL } from '@/constants/auth';
+
+const accessToken = JSON.parse(window.localStorage.getItem('user'))?.token;
+
+const getComment = async (
+  slug: string,
+  headers: HeadersInit = {},
+  options: RequestInit = {},
+): Promise<Response> => {
+  return await fetch(`${BASE_URL}/articles/${slug}/comments`, {
+    ...options,
+    method: 'get',
+    headers: {
+      ...BASE_HEADER,
+      ...headers,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+};
+
+const postComment = async (
+  slug: string,
+  headers: HeadersInit = {},
+  options: RequestInit = {},
+): Promise<Response> => {
+  return await fetch(`${BASE_URL}/articles/${slug}/comments`, {
+    ...options,
+    method: 'post',
+    headers: {
+      ...BASE_HEADER,
+      ...headers,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+};
+
+const deleteComment = async (
+  slug: string,
+  id: number,
+  headers: HeadersInit = {},
+  options: RequestInit = {},
+): Promise<Response> => {
+  return await fetch(`${BASE_URL}/articles/${slug}/comments/${id}`, {
+    ...options,
+    method: 'delete',
+    headers: {
+      ...BASE_HEADER,
+      ...headers,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+};
+
+export { getComment, postComment, deleteComment };

--- a/src/api/profiles.ts
+++ b/src/api/profiles.ts
@@ -1,0 +1,18 @@
+import { BASE_HEADER, BASE_URL } from '@/constants/auth';
+
+const getProfile = async (
+  username: string,
+  headers: HeadersInit = {},
+  options: RequestInit = {},
+): Promise<Response> => {
+  return await fetch(`${BASE_URL}/profiles/${username}`, {
+    ...options,
+    method: 'get',
+    headers: {
+      ...BASE_HEADER,
+      ...headers,
+    },
+  });
+};
+
+export { getProfile };

--- a/src/api/profiles.ts
+++ b/src/api/profiles.ts
@@ -1,5 +1,7 @@
 import { BASE_HEADER, BASE_URL } from '@/constants/auth';
 
+const accessToken = JSON.parse(window.localStorage.getItem('user'))?.token;
+
 const getProfile = async (
   username: string,
   headers: HeadersInit = {},
@@ -11,8 +13,25 @@ const getProfile = async (
     headers: {
       ...BASE_HEADER,
       ...headers,
+      Authorization: `Bearer ${accessToken}`,
     },
   });
 };
 
-export { getProfile };
+const followUser = async (
+  username: string,
+  headers: HeadersInit = {},
+  options: RequestInit = {},
+): Promise<Response> => {
+  return await fetch(`${BASE_URL}/profiles/${username}/follow`, {
+    ...options,
+    method: 'post',
+    headers: {
+      ...BASE_HEADER,
+      ...headers,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+};
+
+export { getProfile, followUser };

--- a/src/api/profiles.ts
+++ b/src/api/profiles.ts
@@ -34,4 +34,20 @@ const followUser = async (
   });
 };
 
-export { getProfile, followUser };
+const unFollowUser = async (
+  username: string,
+  headers: HeadersInit = {},
+  options: RequestInit = {},
+): Promise<Response> => {
+  return await fetch(`${BASE_URL}/profiles/${username}/follow`, {
+    ...options,
+    method: 'delete',
+    headers: {
+      ...BASE_HEADER,
+      ...headers,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+};
+
+export { getProfile, followUser, unFollowUser };

--- a/src/app/[slug]/components/UserProfile.tsx
+++ b/src/app/[slug]/components/UserProfile.tsx
@@ -1,29 +1,80 @@
 import { ProfileResponseType } from '@/types/profile';
 import { usePathname, useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import { AddOutline, SettingsOutline } from 'react-ionicons';
 
-import { followUser } from '@/api/profiles';
+import { followUser, getProfile, unFollowUser } from '@/api/profiles';
 
-interface UserPorfileProps {
-  userData: ProfileResponseType;
-}
-
-const UserProfile = ({ userData }: UserPorfileProps) => {
+const UserProfile = () => {
   const router = useRouter();
   const pathname = usePathname();
   const pathOnlyUserName = pathname?.substring(2);
+  const [userData, setUserData] = useState<undefined | ProfileResponseType>();
 
-  const handleUserFollow = async () => {
+  const fetchUserProfile = async (username: string) => {
     try {
-      const response = await followUser(pathOnlyUserName);
+      const response = await getProfile(username);
       if (!response.ok) {
         throw new Error('Failed to fetch profile');
       }
+      return response.json();
     } catch (error) {
       console.error(error);
       throw error;
     }
   };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data: ProfileResponseType =
+          await fetchUserProfile(pathOnlyUserName);
+        setUserData(data);
+        // 여기서 data 변수에 접근 가능
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    fetchData();
+  }, []);
+
+  const handleUserFollow = async () => {
+    if (userData.profile.following) {
+      try {
+        const response = await unFollowUser(pathOnlyUserName);
+        if (!response.ok) {
+          throw new Error('Failed to fetch profile');
+        }
+        return response.json();
+      } catch (error) {
+        console.error(error);
+        throw error;
+      }
+    } else {
+      try {
+        const response = await followUser(pathOnlyUserName);
+        if (!response.ok) {
+          throw new Error('Failed to fetch profile');
+        }
+        return response.json();
+      } catch (error) {
+        console.error(error);
+        throw error;
+      }
+    }
+  };
+
+  const handleSetFollow = async () => {
+    try {
+      const data = await handleUserFollow();
+      console.log(data);
+      setUserData(data);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  if (userData === undefined) return;
 
   return (
     <div className="user-info">
@@ -49,14 +100,18 @@ const UserProfile = ({ userData }: UserPorfileProps) => {
               </button>
             </div>
           ) : (
-            <div onClick={handleUserFollow} className="w-full justify-end flex">
+            <div onClick={handleSetFollow} className="w-full justify-end flex">
               <button className="btn btn-sm btn-outline-secondary action-btn !flex !items-center !w-fit">
                 <AddOutline
                   cssClasses={'mr-2'}
                   width={'10.5px'}
                   height={'14px'}
                 />
-                <p className="!mb-0">{`Follow ${userData.profile.username}`}</p>
+                <p className="!mb-0">
+                  {userData.profile.following
+                    ? `Unfollow ${userData.profile.username}`
+                    : `Follow ${userData.profile.username}`}
+                </p>
               </button>
             </div>
           )}

--- a/src/app/[slug]/components/UserProfile.tsx
+++ b/src/app/[slug]/components/UserProfile.tsx
@@ -1,0 +1,56 @@
+import { ProfileResponseType } from '@/types/profile';
+import { usePathname, useRouter } from 'next/navigation';
+import { AddOutline, SettingsOutline } from 'react-ionicons';
+
+import { ParseGetLocalStorage } from '@/utils/browserStorage';
+
+interface UserPorfileProps {
+  userData: ProfileResponseType;
+}
+
+const UserProfile = ({ userData }: UserPorfileProps) => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const pathOnlyUserName = pathname?.substring(2);
+  return (
+    <div className="user-info">
+      <div className="container">
+        <div className="flex flex-col items-center">
+          <div className="col-xs-12 col-md-10 offset-md-1 !flex !flex-col !items-center !ml-0">
+            <img src={userData.profile.image} className="user-img" />
+            <h4>{userData.profile.username}</h4>
+            <p>{userData.profile.bio}</p>
+          </div>
+          {pathOnlyUserName === userData.profile.username ? (
+            <div className="w-full justify-end flex">
+              <button className="btn btn-sm btn-outline-secondary action-btn !flex !items-center !w-fit">
+                <AddOutline
+                  cssClasses={'mr-2'}
+                  width={'10.5px'}
+                  height={'14px'}
+                />
+                <p className="!mb-0">{`Follow ${userData.profile.username}`}</p>
+              </button>
+            </div>
+          ) : (
+            <div className="w-full justify-end flex">
+              <button
+                onClick={() => router.push('/settings')}
+                className="btn btn-sm btn-outline-secondary action-btn !flex !items-center !w-fit"
+              >
+                <SettingsOutline
+                  cssClasses={'mr-2'}
+                  width={'10.5px'}
+                  height={'14px'}
+                />
+                <p className="!mb-0">Edit Profile Settings</p>
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UserProfile;

--- a/src/app/[slug]/components/UserProfile.tsx
+++ b/src/app/[slug]/components/UserProfile.tsx
@@ -2,7 +2,7 @@ import { ProfileResponseType } from '@/types/profile';
 import { usePathname, useRouter } from 'next/navigation';
 import { AddOutline, SettingsOutline } from 'react-ionicons';
 
-import { ParseGetLocalStorage } from '@/utils/browserStorage';
+import { followUser } from '@/api/profiles';
 
 interface UserPorfileProps {
   userData: ProfileResponseType;
@@ -12,6 +12,19 @@ const UserProfile = ({ userData }: UserPorfileProps) => {
   const router = useRouter();
   const pathname = usePathname();
   const pathOnlyUserName = pathname?.substring(2);
+
+  const handleUserFollow = async () => {
+    try {
+      const response = await followUser(pathOnlyUserName);
+      if (!response.ok) {
+        throw new Error('Failed to fetch profile');
+      }
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  };
+
   return (
     <div className="user-info">
       <div className="container">
@@ -23,17 +36,6 @@ const UserProfile = ({ userData }: UserPorfileProps) => {
           </div>
           {pathOnlyUserName === userData.profile.username ? (
             <div className="w-full justify-end flex">
-              <button className="btn btn-sm btn-outline-secondary action-btn !flex !items-center !w-fit">
-                <AddOutline
-                  cssClasses={'mr-2'}
-                  width={'10.5px'}
-                  height={'14px'}
-                />
-                <p className="!mb-0">{`Follow ${userData.profile.username}`}</p>
-              </button>
-            </div>
-          ) : (
-            <div className="w-full justify-end flex">
               <button
                 onClick={() => router.push('/settings')}
                 className="btn btn-sm btn-outline-secondary action-btn !flex !items-center !w-fit"
@@ -44,6 +46,17 @@ const UserProfile = ({ userData }: UserPorfileProps) => {
                   height={'14px'}
                 />
                 <p className="!mb-0">Edit Profile Settings</p>
+              </button>
+            </div>
+          ) : (
+            <div onClick={handleUserFollow} className="w-full justify-end flex">
+              <button className="btn btn-sm btn-outline-secondary action-btn !flex !items-center !w-fit">
+                <AddOutline
+                  cssClasses={'mr-2'}
+                  width={'10.5px'}
+                  height={'14px'}
+                />
+                <p className="!mb-0">{`Follow ${userData.profile.username}`}</p>
               </button>
             </div>
           )}

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -3,7 +3,7 @@
 import { FeedResponseType } from '@/types/article';
 import { ProfileResponseType } from '@/types/profile';
 import { usePathname } from 'next/navigation';
-import React, { useEffect, useState } from 'react';
+import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
 
 import Articles from '@/pageComponents/Articles/Articles';
 import Pagination from '@/pageComponents/Pagination/Paginaiton';
@@ -102,6 +102,19 @@ const ProfilePage = () => {
     }
     return favoritedData;
   };
+
+  const getDataAndSetData = (
+    setState: Dispatch<SetStateAction<FeedResponseType>>,
+  ) => {
+    return function (data: FeedResponseType) {
+      console.log('나한테 왔어욤');
+      if (data) {
+        setState(data);
+      }
+    };
+  };
+
+  console.log(authorData);
 
   return (
     <div className="profile-page">

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const page = () => {
+  return (
+    <div>
+      <div>마이페이지</div>
+    </div>
+  );
+};
+
+export default page;

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -2,14 +2,12 @@
 
 import { FeedResponseType } from '@/types/article';
 import { ProfileResponseType } from '@/types/profile';
-import { useRouter } from 'next/navigation';
 import { usePathname } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
 
 import Articles from '@/pageComponents/Articles/Articles';
 
 import { getAuthorArticle, getFavorited } from '@/api/article';
-import { getProfile } from '@/api/profiles';
 
 import { cn } from '@/utils/style';
 
@@ -17,11 +15,9 @@ import UserProfile from './components/UserProfile';
 import { CurrentTabStyle } from './style';
 
 const ProfilePage = () => {
-  const router = useRouter();
   const [currentTab, setCurrentTab] = useState<
     'My Articles' | 'Favorited Articles'
   >('My Articles');
-  const [userData, setUserData] = useState<undefined | ProfileResponseType>();
   const [favoritedData, setFavoritedData] = useState<
     undefined | FeedResponseType
   >();
@@ -35,33 +31,6 @@ const ProfilePage = () => {
       label: 'Favorited Articles',
     },
   ] as const;
-
-  const fetchUserProfile = async (username: string) => {
-    try {
-      const response = await getProfile(username);
-      if (!response.ok) {
-        throw new Error('Failed to fetch profile');
-      }
-      return response.json();
-    } catch (error) {
-      console.error(error);
-      throw error;
-    }
-  };
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const data: ProfileResponseType =
-          await fetchUserProfile(pathOnlyUserName);
-        setUserData(data);
-        // 여기서 data 변수에 접근 가능
-      } catch (error) {
-        console.error(error);
-      }
-    };
-    fetchData();
-  }, []);
 
   const fetchFavoritedData = async (slug: string) => {
     try {
@@ -127,7 +96,7 @@ const ProfilePage = () => {
 
   return (
     <div className="profile-page">
-      {userData && <UserProfile userData={userData} />}
+      {<UserProfile />}
       <div className="container">
         <div className="row">
           <div className="col-xs-12 col-md-10 offset-md-1">

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -6,6 +6,9 @@ import { usePathname } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
 
 import Articles from '@/pageComponents/Articles/Articles';
+import Pagination from '@/pageComponents/Pagination/Paginaiton';
+
+import { PER_PAGE } from '@/constants/pagintaion';
 
 import { getAuthorArticle, getFavorited } from '@/api/article';
 
@@ -14,13 +17,14 @@ import { cn } from '@/utils/style';
 import UserProfile from './components/UserProfile';
 import { CurrentTabStyle } from './style';
 
+type TapType = 'My Articles' | 'Favorited Articles';
+
 const ProfilePage = () => {
-  const [currentTab, setCurrentTab] = useState<
-    'My Articles' | 'Favorited Articles'
-  >('My Articles');
+  const [currentTab, setCurrentTab] = useState<TapType>('My Articles');
   const [favoritedData, setFavoritedData] = useState<
     undefined | FeedResponseType
   >();
+  const [currentPage, setCurrentPage] = useState(1);
 
   const pathname = usePathname();
   const pathOnlyUserName = pathname?.substring(2);
@@ -92,7 +96,12 @@ const ProfilePage = () => {
     fetchAuthor();
   }, [currentTab]);
 
-  console.log(favoritedData, authorData);
+  const getCurrentTabData = (currentTab: TapType) => {
+    if (currentTab === 'My Articles') {
+      return authorData;
+    }
+    return favoritedData;
+  };
 
   return (
     <div className="profile-page">
@@ -122,23 +131,27 @@ const ProfilePage = () => {
               </ul>
             </div>
             {authorData && currentTab === 'My Articles' && (
-              <Articles articles={authorData} />
+              <Articles
+                articles={authorData.articles.slice(
+                  (currentPage - 1) * 10,
+                  currentPage * 10,
+                )}
+              />
             )}
             {favoritedData && currentTab === 'Favorited Articles' && (
-              <Articles articles={favoritedData} />
+              <Articles
+                articles={favoritedData.articles.slice(
+                  (currentPage - 1) * 10,
+                  currentPage * 10,
+                )}
+              />
             )}
-            <ul className="pagination">
-              <li className="page-item active">
-                <a className="page-link" href="">
-                  1
-                </a>
-              </li>
-              <li className="page-item">
-                <a className="page-link" href="">
-                  2
-                </a>
-              </li>
-            </ul>
+            <Pagination
+              totalPage={getCurrentTabData(currentTab)?.articles.length}
+              limit={PER_PAGE}
+              currentPage={currentPage}
+              setCurrentPage={setCurrentPage}
+            />
           </div>
         </div>
       </div>

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -1,9 +1,133 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
 import React from 'react';
 
 const page = () => {
+  const router = useRouter();
   return (
-    <div>
-      <div>마이페이지</div>
+    <div className="profile-page">
+      <div className="user-info">
+        <div className="container">
+          <div className="row">
+            <div className="col-xs-12 col-md-10 offset-md-1">
+              <img src="http://i.imgur.com/Qr71crq.jpg" className="user-img" />
+              <h4>Eric Simons</h4>
+              <p>
+                Cofounder @GoThinkster, lived in Aol's HQ for a few months,
+                kinda looks like Peeta from the Hunger Games
+              </p>
+              <button className="btn btn-sm btn-outline-secondary action-btn">
+                <i className="ion-plus-round"></i>
+                &nbsp; Follow Eric Simons
+              </button>
+              <button
+                onClick={() => router.push('/settings')}
+                className="btn btn-sm btn-outline-secondary action-btn"
+              >
+                <i className="ion-gear-a"></i>
+                &nbsp; Edit Profile Settings
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="container">
+        <div className="row">
+          <div className="col-xs-12 col-md-10 offset-md-1">
+            <div className="articles-toggle">
+              <ul className="nav nav-pills outline-active">
+                <li className="nav-item">
+                  <a className="nav-link active" href="">
+                    My Articles
+                  </a>
+                </li>
+                <li className="nav-item">
+                  <a className="nav-link" href="">
+                    Favorited Articles
+                  </a>
+                </li>
+              </ul>
+            </div>
+
+            <div className="article-preview">
+              <div className="article-meta">
+                <a href="/profile/eric-simons">
+                  <img src="http://i.imgur.com/Qr71crq.jpg" />
+                </a>
+                <div className="info">
+                  <a href="/profile/eric-simons" className="author">
+                    Eric Simons
+                  </a>
+                  <span className="date">January 20th</span>
+                </div>
+                <button className="btn btn-outline-primary btn-sm pull-xs-right">
+                  <i className="ion-heart"></i> 29
+                </button>
+              </div>
+              <a
+                href="/article/how-to-buil-webapps-that-scale"
+                className="preview-link"
+              >
+                <h1>How to build webapps that scale</h1>
+                <p>This is the description for the post.</p>
+                <span>Read more...</span>
+                <ul className="tag-list">
+                  <li className="tag-default tag-pill tag-outline">
+                    realworld
+                  </li>
+                  <li className="tag-default tag-pill tag-outline">
+                    implementations
+                  </li>
+                </ul>
+              </a>
+            </div>
+
+            <div className="article-preview">
+              <div className="article-meta">
+                <a href="/profile/albert-pai">
+                  <img src="http://i.imgur.com/N4VcUeJ.jpg" />
+                </a>
+                <div className="info">
+                  <a href="/profile/albert-pai" className="author">
+                    Albert Pai
+                  </a>
+                  <span className="date">January 20th</span>
+                </div>
+                <button className="btn btn-outline-primary btn-sm pull-xs-right">
+                  <i className="ion-heart"></i> 32
+                </button>
+              </div>
+              <a href="/article/the-song-you" className="preview-link">
+                <h1>
+                  The song you won't ever stop singing. No matter how hard you
+                  try.
+                </h1>
+                <p>This is the description for the post.</p>
+                <span>Read more...</span>
+                <ul className="tag-list">
+                  <li className="tag-default tag-pill tag-outline">Music</li>
+                  <li className="tag-default tag-pill tag-outline">Song</li>
+                </ul>
+              </a>
+            </div>
+
+            <ul className="pagination">
+              <li className="page-item active">
+                <a className="page-link" href="">
+                  1
+                </a>
+              </li>
+              <li className="page-item">
+                <a className="page-link" href="">
+                  2
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/app/[slug]/style.ts
+++ b/src/app/[slug]/style.ts
@@ -1,0 +1,11 @@
+import { cva } from 'class-variance-authority';
+
+const CurrentTabStyle = cva(['nav-link', 'cursor-pointer', '!mb-0'], {
+  variants: {
+    isCurrentTab: {
+      true: ['active'],
+    },
+  },
+});
+
+export { CurrentTabStyle };

--- a/src/app/article/[slug]/components/CommentCard.tsx
+++ b/src/app/article/[slug]/components/CommentCard.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+const CommentCard = () => {
+  return (
+    <div className="card">
+      <div className="card-block">
+        <p className="card-text">
+          With supporting text below as a natural lead-in to additional content.
+        </p>
+      </div>
+      <div className="card-footer">
+        <a href="/profile/author" className="comment-author">
+          <img
+            src="http://i.imgur.com/Qr71crq.jpg"
+            className="comment-author-img"
+          />
+        </a>
+        &nbsp;
+        <a href="/profile/jacob-schmidt" className="comment-author">
+          Jacob Schmidt
+        </a>
+        <span className="date-posted">Dec 29th</span>
+      </div>
+    </div>
+  );
+};
+
+export default CommentCard;

--- a/src/app/article/[slug]/components/FavoriteContainer.tsx
+++ b/src/app/article/[slug]/components/FavoriteContainer.tsx
@@ -1,0 +1,74 @@
+import { ArticleType } from '@/types/article';
+import { produce } from 'immer';
+import React, { Dispatch, SetStateAction, useEffect } from 'react';
+
+import useUserFollow from '@/hooks/useUserFollow';
+
+import UserProfile from './UserProfile';
+
+interface FavoriteContainerProps {
+  article: ArticleType;
+  userNameReplaceSpaceToPercent: string;
+  setArticle: Dispatch<SetStateAction<ArticleType | undefined>>;
+  isMyArticle: boolean;
+}
+
+const FavoriteContainer = ({
+  article,
+  userNameReplaceSpaceToPercent,
+  setArticle,
+  isMyArticle,
+}: FavoriteContainerProps) => {
+  const { handleSetFollow, response, isLoading, isSuccess } = useUserFollow({
+    following: article.author.following,
+    name: article.author.username,
+  });
+
+  useEffect(() => {
+    isSuccess &&
+      setArticle(
+        produce((article) => {
+          article.author = response.profile;
+        }),
+      );
+  }, [isSuccess]);
+
+  useEffect(() => {}, []);
+
+  isLoading && <div>팔로잉 중입니다.</div>;
+  return (
+    <div>
+      <div className="article-actions">
+        <UserProfile
+          userNameReplaceSpaceToPercent={userNameReplaceSpaceToPercent}
+          article={article}
+          isMyArticle={isMyArticle}
+          handleSetFollow={handleSetFollow}
+        />
+      </div>
+
+      <div className="row">
+        <div className="col-xs-12 col-md-8 offset-md-2">
+          <form className="card comment-form">
+            <div className="card-block">
+              <textarea
+                className="form-control"
+                placeholder="Write a comment..."
+                rows="3"
+              ></textarea>
+            </div>
+            <div className="card-footer">
+              <img
+                src="http://i.imgur.com/Qr71crq.jpg"
+                className="comment-author-img"
+              />
+              <button className="btn btn-sm btn-primary">Post Comment</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FavoriteContainer;

--- a/src/app/article/[slug]/components/UserBanner.tsx
+++ b/src/app/article/[slug]/components/UserBanner.tsx
@@ -1,0 +1,53 @@
+import { ArticleType } from '@/types/article';
+import { produce } from 'immer';
+import { Dispatch, SetStateAction, useEffect } from 'react';
+
+import useUserFollow from '@/hooks/useUserFollow';
+
+import UserProfile from './UserProfile';
+
+interface UserBannerProps {
+  article: ArticleType;
+  userNameReplaceSpaceToPercent: string;
+  setArticle: Dispatch<SetStateAction<ArticleType | undefined>>;
+  isMyArticle: boolean;
+}
+
+const UserBanner = ({
+  article,
+  userNameReplaceSpaceToPercent,
+  setArticle,
+  isMyArticle,
+}: UserBannerProps) => {
+  const { handleSetFollow, response, isLoading, isSuccess } = useUserFollow({
+    following: article.author.following,
+    name: article.author.username,
+  });
+
+  useEffect(() => {
+    isSuccess &&
+      setArticle(
+        produce((article) => {
+          article.author = response.profile;
+        }),
+      );
+  }, [isSuccess]);
+
+  isLoading && <div>팔로잉 중입니다.</div>;
+  return (
+    <div className="banner">
+      <div className="container">
+        <h1>{article.title}</h1>
+
+        <UserProfile
+          userNameReplaceSpaceToPercent={userNameReplaceSpaceToPercent}
+          article={article}
+          isMyArticle={isMyArticle}
+          handleSetFollow={handleSetFollow}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default UserBanner;

--- a/src/app/article/[slug]/components/UserProfile.tsx
+++ b/src/app/article/[slug]/components/UserProfile.tsx
@@ -1,0 +1,65 @@
+import { ArticleType } from '@/types/article';
+import { AddOutline, Heart } from 'react-ionicons';
+
+import DayFormatter from '@/utils/dayFormat';
+
+interface UserProfileProps {
+  userNameReplaceSpaceToPercent: string;
+  article: ArticleType;
+  isMyArticle: boolean;
+  handleSetFollow: () => Promise<void>;
+}
+
+const UserProfile = ({
+  userNameReplaceSpaceToPercent,
+  article,
+  isMyArticle,
+  handleSetFollow,
+}: UserProfileProps) => {
+  return (
+    <div className="article-meta !flex">
+      <a href={userNameReplaceSpaceToPercent}>
+        <img src={article.author.image} />
+      </a>
+      <div className="info">
+        <a href={userNameReplaceSpaceToPercent} className="author">
+          {article.author.username}
+        </a>
+        <span className="date">
+          {new DayFormatter(new Date(article.createdAt)).getMonthDate()}
+        </span>
+      </div>
+      {isMyArticle ? (
+        <div className="flex gap-1 items-center">
+          &nbsp;&nbsp;
+          <button className="btn btn-sm btn-outline-secondary">
+            <i className="ion-edit"></i> Edit Article
+          </button>
+          <button className="btn btn-sm btn-outline-danger">
+            <i className="ion-trash-a"></i> Delete Article
+          </button>
+        </div>
+      ) : (
+        <div className="flex gap-1">
+          <button
+            onClick={handleSetFollow}
+            className="btn btn-sm btn-outline-secondary !flex !items-center"
+          >
+            <AddOutline cssClasses={'mr-2'} width={'10.5px'} height={'14px'} />
+            <p className="!mb-0 ">
+              {article.author.following
+                ? `Unfollow ${article.author.username}`
+                : `Follow ${article.author.username}`}
+            </p>
+          </button>
+          <button className="btn btn-sm btn-outline-primary !flex !items-center hover:fill-white">
+            <Heart width={'10.5px'} height={'14px'} color={'#5CB85C'} />
+            &nbsp; Favorite Post <span className="counter">(29)</span>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default UserProfile;

--- a/src/app/article/[slug]/page.tsx
+++ b/src/app/article/[slug]/page.tsx
@@ -1,11 +1,90 @@
 'use client';
 
-import React from 'react';
+import { ArticleType } from '@/types/article';
+import { usePathname } from 'next/navigation';
+import React, { useEffect, useState } from 'react';
+
+import { getArticleDetail } from '@/api/article';
+
+import { ParseGetLocalStorage } from '@/utils/browserStorage';
+
+import FavoriteContainer from './components/FavoriteContainer';
+import UserBanner from './components/UserBanner';
 
 const Page = () => {
+  const [article, setArticle] = useState<undefined | ArticleType>();
+
+  const pathname = usePathname();
+  const pathnameIncludeOnlySlug = pathname?.substring(9);
+
+  const fetchArticleDetail = async (slug: string) => {
+    try {
+      const response = await getArticleDetail(slug);
+      if (!response.ok) {
+        throw new Error('Failed to fetch profile');
+      }
+      return response.json();
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  };
+
+  useEffect(() => {
+    const fetchArticle = async () => {
+      try {
+        const data: { article: ArticleType } = await fetchArticleDetail(
+          pathnameIncludeOnlySlug,
+        );
+        setArticle(data.article);
+        // 여기서 data 변수에 접근 가능
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    fetchArticle();
+  }, []);
+
+  if (!article) return <div>글을 불러오는 중입니다...</div>;
+
+  console.log(article);
+  const userNameReplaceSpaceToPercent = article.author.username.replaceAll(
+    ' ',
+    '%',
+  );
+
+  const isMyArticle =
+    ParseGetLocalStorage('user')?.username === article.author.username;
+
   return (
-    <div>
-      <div>하이</div>
+    <div className="article-page">
+      <UserBanner
+        isMyArticle={isMyArticle}
+        setArticle={setArticle}
+        article={article}
+        userNameReplaceSpaceToPercent={userNameReplaceSpaceToPercent}
+      />
+      <div className="container page">
+        <div className="row article-content">
+          <div className="col-md-12">
+            <p>{article.description}</p>
+            <ul className="tag-list">
+              {article.tagList.map((tag) => (
+                <li key={tag} className="tag-default tag-pill tag-outline">
+                  {tag}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+        <hr />
+        <FavoriteContainer
+          isMyArticle={isMyArticle}
+          setArticle={setArticle}
+          article={article}
+          userNameReplaceSpaceToPercent={userNameReplaceSpaceToPercent}
+        />
+      </div>
     </div>
   );
 };

--- a/src/app/article/[slug]/page.tsx
+++ b/src/app/article/[slug]/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import React from 'react';
+
+const Page = () => {
+  return (
+    <div>
+      <div>하이</div>
+    </div>
+  );
+};
+
+export default Page;

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -1,19 +1,89 @@
-import React from 'react';
+'use client';
+
+import { ArticlePostRequestType } from '@/types/article';
+import { produce } from 'immer';
+import { useRouter } from 'next/navigation';
+import { FormEvent, useState } from 'react';
+
+import { postArticleRegister } from '@/api/article';
 
 const page = () => {
+  const router = useRouter();
+
+  const [formInput, setFormInput] = useState({
+    title: '',
+    description: '',
+    body: '',
+    tagList: [],
+  });
+  const [isLoading, setIsLoading] = useState(false);
+
+  const [error, setError] = useState<null | string>();
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setIsLoading(true);
+    const articleInfo: ArticlePostRequestType = {
+      article: {
+        title: formInput.title,
+        description: formInput.description,
+        body: formInput.body,
+        tagList: formInput.tagList,
+      },
+    };
+    console.log(articleInfo);
+    submitArticle(articleInfo);
+  };
+
+  const submitArticle = async (userInfo: ArticlePostRequestType) => {
+    await postArticleRegister(userInfo).then((res) => {
+      if (res.errors) {
+        setIsLoading(false);
+        const errorText = `${Object.keys(res.errors)} ${
+          Object.values(res.errors)[0]
+        }`;
+        setError(errorText);
+      } else {
+      }
+    });
+  };
+
+  const handleKeyUp: React.KeyboardEventHandler<HTMLInputElement> = (event) => {
+    if (event.key === 'Enter') {
+      const currentValue = event.currentTarget.value;
+      setFormInput(
+        produce((input) => {
+          input.tagList = [...input.tagList, currentValue];
+        }),
+      );
+      event.currentTarget.value = '';
+    }
+  };
+
   return (
     <div className="editor-page">
       <div className="container page">
         <div className="row">
           <div className="col-md-10 offset-md-1 col-xs-12">
-            <ul className="error-messages">
-              <li>That title is required</li>
-            </ul>
+            {error && (
+              <ul className="error-messages">
+                <li>{error}</li>
+              </ul>
+            )}
 
-            <form>
+            <form onSubmit={handleSubmit}>
               <fieldset>
                 <fieldset className="form-group">
                   <input
+                    value={formInput.title}
+                    onChange={(e) =>
+                      setFormInput(
+                        produce((input) => {
+                          input.title = e.target.value;
+                        }),
+                      )
+                    }
+                    name="title"
                     type="text"
                     className="form-control form-control-lg"
                     placeholder="Article Title"
@@ -21,6 +91,15 @@ const page = () => {
                 </fieldset>
                 <fieldset className="form-group">
                   <input
+                    value={formInput.description}
+                    onChange={(e) =>
+                      setFormInput(
+                        produce((input) => {
+                          input.description = e.target.value;
+                        }),
+                      )
+                    }
+                    name="description"
                     type="text"
                     className="form-control"
                     placeholder="What's this article about?"
@@ -28,6 +107,15 @@ const page = () => {
                 </fieldset>
                 <fieldset className="form-group">
                   <textarea
+                    value={formInput.body}
+                    onChange={(e) =>
+                      setFormInput(
+                        produce((input) => {
+                          input.body = e.target.value;
+                        }),
+                      )
+                    }
+                    name="body"
                     className="form-control"
                     rows="8"
                     placeholder="Write your article (in markdown)"
@@ -35,18 +123,29 @@ const page = () => {
                 </fieldset>
                 <fieldset className="form-group">
                   <input
+                    onKeyUp={handleKeyUp}
                     type="text"
                     className="form-control"
                     placeholder="Enter tags"
                   />
-                  <div className="tag-list">
-                    <span className="tag-default tag-pill">
-                      {' '}
-                      <i className="ion-close-round"></i> tag{' '}
-                    </span>
-                  </div>
+                  {formInput.tagList.length > 0 &&
+                    formInput.tagList.map((tag) => (
+                      <div key={tag} className="tag-list">
+                        <span className="tag-default tag-pill">
+                          {' '}
+                          <i className="ion-close-round"></i> {tag}
+                        </span>
+                      </div>
+                    ))}
                 </fieldset>
                 <button
+                  onClick={handleSubmit}
+                  disabled={
+                    isLoading ||
+                    formInput.title.length === 0 ||
+                    formInput.description.length === 0 ||
+                    formInput.body.length === 0
+                  }
                   className="btn btn-lg pull-xs-right btn-primary"
                   type="button"
                 >

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const page = () => {
+  return (
+    <div>
+      <div>새로운 아티클 작성</div>
+    </div>
+  );
+};
+
+export default page;

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -23,12 +23,13 @@ const page = () => {
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setIsLoading(true);
+    const { title, description, body, tagList } = formInput;
     const articleInfo: ArticlePostRequestType = {
       article: {
-        title: formInput.title,
-        description: formInput.description,
-        body: formInput.body,
-        tagList: formInput.tagList,
+        title: title,
+        description: description,
+        body: body,
+        tagList: tagList,
       },
     };
     console.log(articleInfo);
@@ -53,7 +54,7 @@ const page = () => {
       const currentValue = event.currentTarget.value;
       setFormInput(
         produce((input) => {
-          input.tagList = [...input.tagList, currentValue];
+          input.tagList.push(currentValue);
         }),
       );
       event.currentTarget.value = '';

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -2,8 +2,61 @@ import React from 'react';
 
 const page = () => {
   return (
-    <div>
-      <div>새로운 아티클 작성</div>
+    <div className="editor-page">
+      <div className="container page">
+        <div className="row">
+          <div className="col-md-10 offset-md-1 col-xs-12">
+            <ul className="error-messages">
+              <li>That title is required</li>
+            </ul>
+
+            <form>
+              <fieldset>
+                <fieldset className="form-group">
+                  <input
+                    type="text"
+                    className="form-control form-control-lg"
+                    placeholder="Article Title"
+                  />
+                </fieldset>
+                <fieldset className="form-group">
+                  <input
+                    type="text"
+                    className="form-control"
+                    placeholder="What's this article about?"
+                  />
+                </fieldset>
+                <fieldset className="form-group">
+                  <textarea
+                    className="form-control"
+                    rows="8"
+                    placeholder="Write your article (in markdown)"
+                  ></textarea>
+                </fieldset>
+                <fieldset className="form-group">
+                  <input
+                    type="text"
+                    className="form-control"
+                    placeholder="Enter tags"
+                  />
+                  <div className="tag-list">
+                    <span className="tag-default tag-pill">
+                      {' '}
+                      <i className="ion-close-round"></i> tag{' '}
+                    </span>
+                  </div>
+                </fieldset>
+                <button
+                  className="btn btn-lg pull-xs-right btn-primary"
+                  type="button"
+                >
+                  Publish Article
+                </button>
+              </fieldset>
+            </form>
+          </div>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
+import ProtecTedRoute from '@/composables/ProtectedRoute.tsx/ProtectedRoute';
 import { LoginPostRequestType } from '@/types/auth';
 import { produce } from 'immer';
 import { useRouter } from 'next/navigation';
-import  { FormEvent, useState } from 'react';
+import { FormEvent, useState } from 'react';
 
 import { postUserLogin } from '@/api/auth';
 
@@ -14,7 +15,7 @@ const page = () => {
     email: '',
     password: '',
   });
-  const [isLoading,setIsLoading] = useState(false)
+  const [isLoading, setIsLoading] = useState(false);
 
   const [error, setError] = useState<null | string>();
 
@@ -24,15 +25,14 @@ const page = () => {
     const EventTarget = e.target;
     const userInfo: LoginPostRequestType = {
       user: {
-        email: EventTarget.email.value,
-        password: EventTarget.password.value,
+        email: (EventTarget as e.target).email.value,
+        password: (EventTarget as e.target).password.value,
       },
     };
     login(userInfo);
   };
 
   const login = async (userInfo: LoginPostRequestType) => {
-
     await postUserLogin(userInfo).then((res) => {
       if (res.errors) {
         setIsLoading(false);
@@ -41,6 +41,7 @@ const page = () => {
         }`;
         setError(errorText);
       } else {
+        localStorage.setItem('user', JSON.stringify(res.user));
         router.push('/');
       }
     });
@@ -96,8 +97,9 @@ const page = () => {
                   />
                 </div>
                 <button
-                type='submit'
+                  type="submit"
                   disabled={
+                    isLoading ||
                     formInput.email.length === 0 ||
                     formInput.password.length === 0
                   }
@@ -114,4 +116,4 @@ const page = () => {
   );
 };
 
-export default page;
+export default ProtecTedRoute(page);

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -22,11 +22,11 @@ const page = () => {
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setIsLoading(true);
-    const EventTarget = e.target;
+    const eventTarget = e.target;
     const userInfo: LoginPostRequestType = {
       user: {
-        email: (EventTarget as e.target).email.value,
-        password: (EventTarget as e.target).password.value,
+        email: eventTarget.email.value,
+        password: eventTarget.password.value,
       },
     };
     login(userInfo);

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,7 +3,7 @@
 import { LoginPostRequestType } from '@/types/auth';
 import { produce } from 'immer';
 import { useRouter } from 'next/navigation';
-import React, { FormEvent, useState } from 'react';
+import  { FormEvent, useState } from 'react';
 
 import { postUserLogin } from '@/api/auth';
 
@@ -11,27 +11,31 @@ const page = () => {
   const router = useRouter();
 
   const [formInput, setFormInput] = useState({
-    username: '',
     email: '',
     password: '',
   });
+  const [isLoading,setIsLoading] = useState(false)
 
   const [error, setError] = useState<null | string>();
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    setIsLoading(true);
+    const EventTarget = e.target;
     const userInfo: LoginPostRequestType = {
       user: {
-        email: e.target.email.value,
-        password: e.target.password.value,
+        email: EventTarget.email.value,
+        password: EventTarget.password.value,
       },
     };
     login(userInfo);
   };
 
   const login = async (userInfo: LoginPostRequestType) => {
+
     await postUserLogin(userInfo).then((res) => {
       if (res.errors) {
+        setIsLoading(false);
         const errorText = `${Object.keys(res.errors)} ${
           Object.values(res.errors)[0]
         }`;
@@ -92,6 +96,7 @@ const page = () => {
                   />
                 </div>
                 <button
+                type='submit'
                   disabled={
                     formInput.email.length === 0 ||
                     formInput.password.length === 0

--- a/src/app/mypage/[slug]/page.tsx
+++ b/src/app/mypage/[slug]/page.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const page = () => {
+  return (
+    <div>
+      <div>마이페이지</div>
+    </div>
+  );
+};
+
+export default page;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,39 @@
-export default function Home() {
+'use client';
+
+import ProtecTedRoute from '@/composables/ProtectedRoute.tsx/ProtectedRoute';
+import { GlobalFeedResponseType } from '@/types/article';
+import { useEffect, useState } from 'react';
+
+import { getGlobalFeed } from '@/api/article';
+
+const Home = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [globalFeeds, setGlobalFeeds] =
+    useState<GlobalFeedResponseType | null>();
+  const [currentTab, setCurrentTab] = useState<'myFeed' | 'globalFeed'>(
+    'globalFeed',
+  );
+  const [user, setUser] = useState();
+
+  useEffect(() => {
+    setUser(JSON.parse(window.localStorage.getItem('user'))?.username);
+  }, []);
+  const globalFeed = async () => {
+    await getGlobalFeed().then((res) => {
+      if (res.errors) {
+        setIsLoading(false);
+      } else {
+        setIsLoading(true);
+        console.log(res);
+        setGlobalFeeds(res);
+      }
+    });
+  };
+
+  useEffect(() => {
+    globalFeed();
+  }, []);
+
   return (
     <main className="mb-3 mt-2 flex bg-red-400  text-blue-500">
       <div className="home-page">
@@ -14,11 +49,13 @@ export default function Home() {
             <div className="col-md-9">
               <div className="feed-toggle">
                 <ul className="nav nav-pills outline-active">
-                  <li className="nav-item">
-                    <a className="nav-link" href="">
-                      Your Feed
-                    </a>
-                  </li>
+                  {user && (
+                    <li className="nav-item">
+                      <a className="nav-link" href="">
+                        Your Feed
+                      </a>
+                    </li>
+                  )}
                   <li className="nav-item">
                     <a className="nav-link active" href="">
                       Global Feed
@@ -27,71 +64,41 @@ export default function Home() {
                 </ul>
               </div>
 
-              <div className="article-preview">
-                <div className="article-meta">
-                  <a href="/profile/eric-simons">
-                    <img src="http://i.imgur.com/Qr71crq.jpg" />
-                  </a>
-                  <div className="info">
-                    <a href="/profile/eric-simons" className="author">
-                      Eric Simons
+              {globalFeeds?.articles.map((feed) => {
+                return (
+                  <div key={feed.author.username} className="article-preview">
+                    <div className="article-meta">
+                      <a href="/profile/eric-simons">
+                        <img src={feed.author.image} />
+                      </a>
+                      <div className="info">
+                        <a href="/profile/eric-simons" className="author">
+                          Eric Simons
+                        </a>
+                        <span className="date">January 20th</span>
+                      </div>
+                      <button className="btn btn-outline-primary btn-sm pull-xs-right">
+                        <i className="ion-heart"></i> {feed.favoritesCount}
+                      </button>
+                    </div>
+                    <a href={`/article/${feed.slug}`} className="preview-link">
+                      <h1>{feed.slug}</h1>
+                      <p>{feed.description}</p>
+                      <span>Read more...</span>
+                      <ul className="tag-list">
+                        {feed.tagList.map((tag) => (
+                          <li
+                            key={tag}
+                            className="tag-default tag-pill tag-outline"
+                          >
+                            {tag}
+                          </li>
+                        ))}
+                      </ul>
                     </a>
-                    <span className="date">January 20th</span>
                   </div>
-                  <button className="btn btn-outline-primary btn-sm pull-xs-right">
-                    <i className="ion-heart"></i> 29
-                  </button>
-                </div>
-                <a
-                  href="/article/how-to-build-webapps-that-scale"
-                  className="preview-link"
-                >
-                  <h1>How to build webapps that scale</h1>
-                  <p>This is the description for the post.</p>
-                  <span>Read more...</span>
-                  <ul className="tag-list">
-                    <li className="tag-default tag-pill tag-outline">
-                      realworld
-                    </li>
-                    <li className="tag-default tag-pill tag-outline">
-                      implementations
-                    </li>
-                  </ul>
-                </a>
-              </div>
-
-              <div className="article-preview">
-                <div className="article-meta">
-                  <a href="/profile/albert-pai">
-                    <img src="http://i.imgur.com/N4VcUeJ.jpg" />
-                  </a>
-                  <div className="info">
-                    <a href="/profile/albert-pai" className="author">
-                      Albert Pai
-                    </a>
-                    <span className="date">January 20th</span>
-                  </div>
-                  <button className="btn btn-outline-primary btn-sm pull-xs-right">
-                    <i className="ion-heart"></i> 32
-                  </button>
-                </div>
-                <a href="/article/the-song-you" className="preview-link">
-                  <h1>
-                    The song you won't ever stop singing. No matter how hard you
-                    try.
-                  </h1>
-                  <p>This is the description for the post.</p>
-                  <span>Read more...</span>
-                  <ul className="tag-list">
-                    <li className="tag-default tag-pill tag-outline">
-                      realworld
-                    </li>
-                    <li className="tag-default tag-pill tag-outline">
-                      implementations
-                    </li>
-                  </ul>
-                </a>
-              </div>
+                );
+              })}
 
               <ul className="pagination">
                 <li className="page-item active">
@@ -144,4 +151,5 @@ export default function Home() {
       </div>
     </main>
   );
-}
+};
+export default ProtecTedRoute(Home);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,16 +4,21 @@ import ProtecTedRoute from '@/composables/ProtectedRoute.tsx/ProtectedRoute';
 import { FeedResponseType } from '@/types/article';
 import { useEffect, useState } from 'react';
 
+import Pagination from '@/pageComponents/Pagination/Paginaiton';
+
+import { PER_PAGE } from '@/constants/pagintaion';
+
 import { getGlobalFeed, getMyFeed } from '@/api/article';
+
+type HomePageTabType = 'myFeed' | 'globalFeed';
 
 const Home = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [globalFeeds, setGlobalFeeds] = useState<FeedResponseType | null>();
   const [myFeeds, setMyFeeds] = useState<FeedResponseType | null>();
-  const [currentTab, setCurrentTab] = useState<'myFeed' | 'globalFeed'>(
-    'globalFeed',
-  );
+  const [currentTab, setCurrentTab] = useState<HomePageTabType>('globalFeed');
   const [user, setUser] = useState();
+  const [currentPage, setCurrentPage] = useState(1);
 
   const fetchGlobalFeed = async () => {
     await getGlobalFeed().then((res) => {
@@ -40,6 +45,13 @@ const Home = () => {
       setIsLoading(false);
       throw error;
     }
+  };
+
+  const getCurrentTabData = (currentTab: HomePageTabType) => {
+    if (currentTab === 'myFeed') {
+      return myFeeds;
+    }
+    return globalFeeds;
   };
 
   useEffect(() => {
@@ -193,18 +205,12 @@ const Home = () => {
                 <div>피드 없음</div>
               )}
 
-              <ul className="pagination">
-                <li className="page-item active">
-                  <a className="page-link" href="">
-                    1
-                  </a>
-                </li>
-                <li className="page-item">
-                  <a className="page-link" href="">
-                    2
-                  </a>
-                </li>
-              </ul>
+              <Pagination
+                totalPage={getCurrentTabData(currentTab)?.articles.length}
+                limit={PER_PAGE}
+                currentPage={currentPage}
+                setCurrentPage={setCurrentPage}
+              />
             </div>
 
             <div className="col-md-3">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,23 +1,20 @@
 'use client';
 
 import ProtecTedRoute from '@/composables/ProtectedRoute.tsx/ProtectedRoute';
-import { GlobalFeedResponseType } from '@/types/article';
+import { FeedResponseType } from '@/types/article';
 import { useEffect, useState } from 'react';
 
-import { getGlobalFeed } from '@/api/article';
+import { getGlobalFeed, getMyFeed } from '@/api/article';
 
 const Home = () => {
   const [isLoading, setIsLoading] = useState(false);
-  const [globalFeeds, setGlobalFeeds] =
-    useState<GlobalFeedResponseType | null>();
+  const [globalFeeds, setGlobalFeeds] = useState<FeedResponseType | null>();
+  const [myFeeds, setMyFeeds] = useState<FeedResponseType | null>();
   const [currentTab, setCurrentTab] = useState<'myFeed' | 'globalFeed'>(
     'globalFeed',
   );
   const [user, setUser] = useState();
 
-  useEffect(() => {
-    setUser(JSON.parse(window.localStorage.getItem('user'))?.username);
-  }, []);
   const globalFeed = async () => {
     await getGlobalFeed().then((res) => {
       if (res.errors) {
@@ -29,6 +26,29 @@ const Home = () => {
       }
     });
   };
+
+  const myFeed = async () => {
+    await getMyFeed().then((res) => {
+      if (res.errors) {
+        setIsLoading(false);
+      } else {
+        setIsLoading(true);
+        console.log(res);
+        setGlobalFeeds(res);
+      }
+    });
+  };
+
+  useEffect(() => {
+    if (user) {
+      setCurrentTab('myFeed');
+      myFeed();
+    }
+  }, [user]);
+
+  useEffect(() => {
+    setUser(JSON.parse(window.localStorage.getItem('user'))?.username);
+  }, []);
 
   useEffect(() => {
     globalFeed();
@@ -50,55 +70,115 @@ const Home = () => {
               <div className="feed-toggle">
                 <ul className="nav nav-pills outline-active">
                   {user && (
-                    <li className="nav-item">
-                      <a className="nav-link" href="">
+                    <li
+                      onClick={() => setCurrentTab('myFeed')}
+                      className="nav-item"
+                    >
+                      <p
+                        className={`nav-link ${
+                          currentTab === 'myFeed' ? 'active' : ''
+                        }`}
+                      >
                         Your Feed
-                      </a>
+                      </p>
                     </li>
                   )}
-                  <li className="nav-item">
-                    <a className="nav-link active" href="">
+                  <li
+                    onClick={() => setCurrentTab('globalFeed')}
+                    className="nav-item"
+                  >
+                    <p
+                      className={`nav-link ${
+                        currentTab === 'globalFeed' ? 'active' : ''
+                      }`}
+                    >
                       Global Feed
-                    </a>
+                    </p>
                   </li>
                 </ul>
               </div>
 
-              {globalFeeds?.articles.map((feed) => {
-                return (
-                  <div key={feed.author.username} className="article-preview">
-                    <div className="article-meta">
-                      <a href="/profile/eric-simons">
-                        <img src={feed.author.image} />
-                      </a>
-                      <div className="info">
-                        <a href="/profile/eric-simons" className="author">
-                          Eric Simons
+              {currentTab === 'globalFeed' &&
+                globalFeeds?.articles.map((feed) => {
+                  return (
+                    <div key={feed.author.username} className="article-preview">
+                      <div className="article-meta">
+                        <a href="/profile/eric-simons">
+                          <img src={feed.author.image} />
                         </a>
-                        <span className="date">January 20th</span>
+                        <div className="info">
+                          <a href="/profile/eric-simons" className="author">
+                            Eric Simons
+                          </a>
+                          <span className="date">January 20th</span>
+                        </div>
+                        <button className="btn btn-outline-primary btn-sm pull-xs-right">
+                          <i className="ion-heart"></i> {feed.favoritesCount}
+                        </button>
                       </div>
-                      <button className="btn btn-outline-primary btn-sm pull-xs-right">
-                        <i className="ion-heart"></i> {feed.favoritesCount}
-                      </button>
+                      <a
+                        href={`/article/${feed.slug}`}
+                        className="preview-link"
+                      >
+                        <h1>{feed.slug}</h1>
+                        <p>{feed.description}</p>
+                        <span>Read more...</span>
+                        <ul className="tag-list">
+                          {feed.tagList.map((tag) => (
+                            <li
+                              key={tag}
+                              className="tag-default tag-pill tag-outline"
+                            >
+                              {tag}
+                            </li>
+                          ))}
+                        </ul>
+                      </a>
                     </div>
-                    <a href={`/article/${feed.slug}`} className="preview-link">
-                      <h1>{feed.slug}</h1>
-                      <p>{feed.description}</p>
-                      <span>Read more...</span>
-                      <ul className="tag-list">
-                        {feed.tagList.map((tag) => (
-                          <li
-                            key={tag}
-                            className="tag-default tag-pill tag-outline"
-                          >
-                            {tag}
-                          </li>
-                        ))}
-                      </ul>
-                    </a>
-                  </div>
-                );
-              })}
+                  );
+                })}
+              {currentTab === 'myFeed' && myFeeds?.articles.length > 0 ? (
+                myFeeds?.articles.map((feed) => {
+                  return (
+                    <div key={feed.author.username} className="article-preview">
+                      <div className="article-meta">
+                        <a href="/profile/eric-simons">
+                          <img src={feed.author.image} />
+                        </a>
+                        <div className="info">
+                          <a href="/profile/eric-simons" className="author">
+                            Eric Simons
+                          </a>
+                          <span className="date">January 20th</span>
+                        </div>
+                        <button className="btn btn-outline-primary btn-sm pull-xs-right">
+                          <i className="ion-heart"></i> {feed.favoritesCount}
+                        </button>
+                      </div>
+                      <a
+                        href={`/article/${feed.slug}`}
+                        className="preview-link"
+                      >
+                        <h1>{feed.slug}</h1>
+                        <p>{feed.description}</p>
+                        <span>Read more...</span>
+                        <ul className="tag-list">
+                          {feed.tagList.map((tag) => (
+                            <li
+                              key={tag}
+                              className="tag-default tag-pill tag-outline"
+                            >
+                              {tag}
+                            </li>
+                          ))}
+                        </ul>
+                      </a>
+                    </div>
+                  );
+                })
+              ) : (
+                <div>피드 없음</div>
+              )}
 
               <ul className="pagination">
                 <li className="page-item active">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,7 +38,6 @@ const Home = () => {
       return response.json();
     } catch (error) {
       setIsLoading(false);
-      console.error(error);
       throw error;
     }
   };
@@ -47,7 +46,7 @@ const Home = () => {
     const fetchMyFeed = async () => {
       try {
         const data: FeedResponseType = await fetchGetMyFeed();
-        setGlobalFeeds(data);
+        setMyFeeds(data);
         // 여기서 data 변수에 접근 가능
       } catch (error) {
         console.error(error);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,7 +15,7 @@ const Home = () => {
   );
   const [user, setUser] = useState();
 
-  const globalFeed = async () => {
+  const fetchGlobalFeed = async () => {
     await getGlobalFeed().then((res) => {
       if (res.errors) {
         setIsLoading(false);
@@ -27,7 +27,7 @@ const Home = () => {
     });
   };
 
-  const myFeed = async () => {
+  const fetchMyFeed = async () => {
     await getMyFeed().then((res) => {
       if (res.errors) {
         setIsLoading(false);
@@ -42,7 +42,7 @@ const Home = () => {
   useEffect(() => {
     if (user) {
       setCurrentTab('myFeed');
-      myFeed();
+      fetchMyFeed();
     }
   }, [user]);
 
@@ -51,8 +51,10 @@ const Home = () => {
   }, []);
 
   useEffect(() => {
-    globalFeed();
+    fetchGlobalFeed();
   }, []);
+
+  console.log(globalFeeds);
 
   return (
     <main className="mb-3 mt-2 flex bg-red-400  text-blue-500">
@@ -99,7 +101,8 @@ const Home = () => {
               </div>
 
               {currentTab === 'globalFeed' &&
-                globalFeeds?.articles.map((feed) => {
+                globalFeeds &&
+                globalFeeds?.articles?.map((feed) => {
                   return (
                     <div key={feed.author.username} className="article-preview">
                       <div className="article-meta">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,19 +27,32 @@ const Home = () => {
     });
   };
 
-  const fetchMyFeed = async () => {
-    await getMyFeed().then((res) => {
-      if (res.errors) {
-        setIsLoading(false);
-      } else {
-        setIsLoading(true);
-        console.log(res);
-        setGlobalFeeds(res);
+  const fetchGetMyFeed = async () => {
+    setIsLoading(true);
+    try {
+      const response = await getMyFeed();
+      if (!response.ok) {
+        throw new Error('Failed to fetch profile');
       }
-    });
+      setIsLoading(false);
+      return response.json();
+    } catch (error) {
+      setIsLoading(false);
+      console.error(error);
+      throw error;
+    }
   };
 
   useEffect(() => {
+    const fetchMyFeed = async () => {
+      try {
+        const data: FeedResponseType = await fetchGetMyFeed();
+        setGlobalFeeds(data);
+        // 여기서 data 변수에 접근 가능
+      } catch (error) {
+        console.error(error);
+      }
+    };
     if (user) {
       setCurrentTab('myFeed');
       fetchMyFeed();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,8 +54,6 @@ const Home = () => {
     fetchGlobalFeed();
   }, []);
 
-  console.log(globalFeeds);
-
   return (
     <main className="mb-3 mt-2 flex bg-red-400  text-blue-500">
       <div className="home-page">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const page = () => {
+  return (
+    <div>
+      <div>세팅페이지</div>
+    </div>
+  );
+};
+
+export default page;

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -2,8 +2,65 @@ import React from 'react';
 
 const page = () => {
   return (
-    <div>
-      <div>세팅페이지</div>
+    <div className="settings-page">
+      <div className="container page">
+        <div className="row">
+          <div className="col-md-6 offset-md-3 col-xs-12">
+            <h1 className="text-xs-center">Your Settings</h1>
+
+            <ul className="error-messages">
+              <li>That name is required</li>
+            </ul>
+
+            <form>
+              <fieldset>
+                <fieldset className="form-group">
+                  <input
+                    className="form-control"
+                    type="text"
+                    placeholder="URL of profile picture"
+                  />
+                </fieldset>
+                <fieldset className="form-group">
+                  <input
+                    className="form-control form-control-lg"
+                    type="text"
+                    placeholder="Your Name"
+                  />
+                </fieldset>
+                <fieldset className="form-group">
+                  <textarea
+                    className="form-control form-control-lg"
+                    rows="8"
+                    placeholder="Short bio about you"
+                  ></textarea>
+                </fieldset>
+                <fieldset className="form-group">
+                  <input
+                    className="form-control form-control-lg"
+                    type="text"
+                    placeholder="Email"
+                  />
+                </fieldset>
+                <fieldset className="form-group">
+                  <input
+                    className="form-control form-control-lg"
+                    type="password"
+                    placeholder="New Password"
+                  />
+                </fieldset>
+                <button className="btn btn-lg btn-primary pull-xs-right">
+                  Update Settings
+                </button>
+              </fieldset>
+            </form>
+            <hr />
+            <button className="btn btn-outline-danger">
+              Or click here to logout.
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -58,7 +58,7 @@ const page = () => {
         }`;
         setError(errorText);
       } else {
-        router.push(`/${username}`);
+        router.push(`/@${username}`);
       }
     });
   };
@@ -176,7 +176,9 @@ const page = () => {
                   />
                 </fieldset>
                 <button
-                  disabled={!(profilePictureUrl && username && email)}
+                  disabled={
+                    !(profilePictureUrl && username && password && email)
+                  }
                   className="btn btn-lg btn-primary pull-xs-right"
                   onClick={handleSubmit}
                 >

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -11,7 +11,7 @@ import { updateUser } from '@/api/auth';
 
 import { LocalStorage, ParseGetLocalStorage } from '@/utils/browserStorage';
 
-const page = () => {
+const Settings = () => {
   const router = useRouter();
 
   const handleClickLogout = () => {
@@ -64,20 +64,17 @@ const page = () => {
   };
 
   useEffect(() => {
-    console.log(previousUserInfo);
     if (previousUserInfo) {
       setFormInput(
         produce((input) => {
-          const { email, password, username, image } = previousUserInfo;
+          const { email, username, image } = previousUserInfo;
           input.email = email;
           input.username = username;
           input.profilePictureUrl = image;
         }),
       );
     }
-  }, [previousUserInfo]);
-
-  console.log(formInput);
+  }, []);
 
   return (
     <div className="settings-page">
@@ -200,4 +197,4 @@ const page = () => {
   );
 };
 
-export default page;
+export default Settings;

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,6 +1,84 @@
-import React from 'react';
+'use client';
+
+import { UpdateUserType } from '@/types/auth';
+import { produce } from 'immer';
+import { useRouter } from 'next/navigation';
+import React, { FormEvent, useEffect, useState } from 'react';
+
+import { User } from '@/constants/localStorageKey';
+
+import { updateUser } from '@/api/auth';
+
+import { LocalStorage, ParseGetLocalStorage } from '@/utils/browserStorage';
 
 const page = () => {
+  const router = useRouter();
+
+  const handleClickLogout = () => {
+    LocalStorage.remove(User);
+    router.push('/');
+  };
+
+  const [formInput, setFormInput] = useState({
+    profilePictureUrl: '',
+    username: '',
+    bio: '',
+    email: '',
+    password: '',
+  });
+  const [isLoading, setIsLoading] = useState(false);
+
+  const [error, setError] = useState<null | string>();
+
+  const { profilePictureUrl, username, bio, email, password } = formInput;
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setIsLoading(true);
+    const articleInfo: UpdateUserType = {
+      user: {
+        email,
+        password,
+        username,
+        bio,
+        image: profilePictureUrl,
+      },
+    };
+    submitArticle(articleInfo);
+  };
+
+  const previousUserInfo = JSON.parse(LocalStorage.get(User));
+
+  const submitArticle = async (userInfo: UpdateUserType) => {
+    await updateUser(userInfo).then((res) => {
+      if (res.errors) {
+        setIsLoading(false);
+        const errorText = `${Object.keys(res.errors)} ${
+          Object.values(res.errors)[0]
+        }`;
+        setError(errorText);
+      } else {
+        router.push(`/${username}`);
+      }
+    });
+  };
+
+  useEffect(() => {
+    console.log(previousUserInfo);
+    if (previousUserInfo) {
+      setFormInput(
+        produce((input) => {
+          const { email, password, username, image } = previousUserInfo;
+          input.email = email;
+          input.username = username;
+          input.profilePictureUrl = image;
+        }),
+      );
+    }
+  }, [previousUserInfo]);
+
+  console.log(formInput);
+
   return (
     <div className="settings-page">
       <div className="container page">
@@ -8,14 +86,25 @@ const page = () => {
           <div className="col-md-6 offset-md-3 col-xs-12">
             <h1 className="text-xs-center">Your Settings</h1>
 
-            <ul className="error-messages">
-              <li>That name is required</li>
-            </ul>
+            {error && (
+              <ul className="error-messages">
+                <li>That name is required</li>
+              </ul>
+            )}
 
             <form>
               <fieldset>
                 <fieldset className="form-group">
                   <input
+                    value={profilePictureUrl}
+                    onChange={(e) =>
+                      setFormInput(
+                        produce((input) => {
+                          input.profilePictureUrl = e.target.value;
+                        }),
+                      )
+                    }
+                    name="profilePictureUrl"
                     className="form-control"
                     type="text"
                     placeholder="URL of profile picture"
@@ -23,6 +112,15 @@ const page = () => {
                 </fieldset>
                 <fieldset className="form-group">
                   <input
+                    value={username}
+                    onChange={(e) =>
+                      setFormInput(
+                        produce((input) => {
+                          input.username = e.target.value;
+                        }),
+                      )
+                    }
+                    name="username"
                     className="form-control form-control-lg"
                     type="text"
                     placeholder="Your Name"
@@ -30,6 +128,15 @@ const page = () => {
                 </fieldset>
                 <fieldset className="form-group">
                   <textarea
+                    value={bio}
+                    onChange={(e) =>
+                      setFormInput(
+                        produce((input) => {
+                          input.bio = e.target.value;
+                        }),
+                      )
+                    }
+                    name="bio"
                     className="form-control form-control-lg"
                     rows="8"
                     placeholder="Short bio about you"
@@ -37,6 +144,15 @@ const page = () => {
                 </fieldset>
                 <fieldset className="form-group">
                   <input
+                    value={email}
+                    onChange={(e) =>
+                      setFormInput(
+                        produce((input) => {
+                          input.email = e.target.value;
+                        }),
+                      )
+                    }
+                    name="email"
                     className="form-control form-control-lg"
                     type="text"
                     placeholder="Email"
@@ -44,18 +160,35 @@ const page = () => {
                 </fieldset>
                 <fieldset className="form-group">
                   <input
+                    value={password}
+                    onChange={(e) =>
+                      setFormInput(
+                        produce((input) => {
+                          input.password = e.target.value;
+                        }),
+                      )
+                    }
+                    autoComplete="on"
+                    name="password"
                     className="form-control form-control-lg"
                     type="password"
                     placeholder="New Password"
                   />
                 </fieldset>
-                <button className="btn btn-lg btn-primary pull-xs-right">
+                <button
+                  disabled={!(profilePictureUrl && username && email)}
+                  className="btn btn-lg btn-primary pull-xs-right"
+                  onClick={handleSubmit}
+                >
                   Update Settings
                 </button>
               </fieldset>
             </form>
             <hr />
-            <button className="btn btn-outline-danger">
+            <button
+              onClick={handleClickLogout}
+              className="btn btn-outline-danger"
+            >
               Or click here to logout.
             </button>
           </div>

--- a/src/app/signUp/page.tsx
+++ b/src/app/signUp/page.tsx
@@ -4,7 +4,7 @@ import { RegisterPostRequestType } from '@/types/auth';
 import { produce } from 'immer';
 import { useRouter } from 'next/navigation';
 import React, { FormEvent, useState } from 'react';
-
+import Link from 'next/link';
 import { postUserRegister } from '@/api/auth';
 
 const page = () => {
@@ -26,10 +26,10 @@ const page = () => {
         password: e.target.password.value,
       },
     };
-    signOutUser(userInfo);
+    signUpUser(userInfo);
   };
 
-  const signOutUser = async (userInfo: RegisterPostRequestType) => {
+  const signUpUser = async (userInfo: RegisterPostRequestType) => {
     await postUserRegister(userInfo).then((res) => {
       if (res.errors) {
         const errorText = `${Object.keys(res.errors)} ${
@@ -49,7 +49,7 @@ const page = () => {
           <div className="col-md-6 offset-md-3 col-xs-12">
             <h1 className="text-xs-center">Sign up</h1>
             <p className="text-xs-center">
-              <a href="/login">Have an account?</a>
+              <Link href="/login">Have an account?</Link>
             </p>
 
             {error && (

--- a/src/app/signUp/page.tsx
+++ b/src/app/signUp/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import ProtecTedRoute from '@/composables/ProtectedRoute.tsx/ProtectedRoute';
 import { RegisterPostRequestType } from '@/types/auth';
 import { produce } from 'immer';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import React, { FormEvent, useState } from 'react';
-import Link from 'next/link';
+
 import { postUserRegister } from '@/api/auth';
 
 const page = () => {
@@ -125,4 +127,4 @@ const page = () => {
   );
 };
 
-export default page;
+export default ProtecTedRoute(page);

--- a/src/composables/ProtectedRoute.tsx/ProtectedRoute.tsx
+++ b/src/composables/ProtectedRoute.tsx/ProtectedRoute.tsx
@@ -1,0 +1,25 @@
+import { usePathname, useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+export default function ProtecTedRoute(Component) {
+  return function ProtectedRoute({ ...props }) {
+    const router = useRouter();
+    const path = usePathname();
+    console.log(path);
+    const user =
+      localStorage.getItem('user') &&
+      JSON.parse(localStorage.getItem('user') as string);
+    const userIsAuthenticated = !!user !== false;
+
+    useEffect(() => {
+      if (userIsAuthenticated && path === '/login') {
+        router.push('/');
+      }
+      if (!userIsAuthenticated && path === '/settings') {
+        router.push('/login');
+      }
+    }, [userIsAuthenticated, router, path]);
+
+    return <Component {...props} />;
+  };
+}

--- a/src/composables/ProtectedRoute.tsx/ProtectedRoute.tsx
+++ b/src/composables/ProtectedRoute.tsx/ProtectedRoute.tsx
@@ -1,15 +1,19 @@
+'use client';
+
 import { usePathname, useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function ProtecTedRoute(Component) {
   return function ProtectedRoute({ ...props }) {
     const router = useRouter();
     const path = usePathname();
-    console.log(path);
-    const user =
-      localStorage.getItem('user') &&
-      JSON.parse(localStorage.getItem('user') as string);
+    const [user, setUser] = useState<string | null>();
+
     const userIsAuthenticated = !!user !== false;
+
+    useEffect(() => {
+      setUser(window.localStorage.getItem('user'));
+    }, []);
 
     useEffect(() => {
       if (userIsAuthenticated && path === '/login') {

--- a/src/composables/ProtectedRoute.tsx/ProtectedRoute.tsx
+++ b/src/composables/ProtectedRoute.tsx/ProtectedRoute.tsx
@@ -7,22 +7,17 @@ export default function ProtecTedRoute(Component) {
   return function ProtectedRoute({ ...props }) {
     const router = useRouter();
     const path = usePathname();
-    const [user, setUser] = useState<string | null>();
 
-    const userIsAuthenticated = !!user !== false;
-
-    useEffect(() => {
-      setUser(window.localStorage.getItem('user'));
-    }, []);
+    const IsAuthenticated = !!window.localStorage.getItem('user');
 
     useEffect(() => {
-      if (userIsAuthenticated && path === '/login') {
+      if (IsAuthenticated && path === '/login') {
         router.push('/');
       }
-      if (!userIsAuthenticated && path === '/settings') {
+      if (!IsAuthenticated && path === '/settings') {
         router.push('/login');
       }
-    }, [userIsAuthenticated, router, path]);
+    }, [IsAuthenticated, router, path]);
 
     return <Component {...props} />;
   };

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -1,7 +1,7 @@
 const BASE_URL = process.env.NEXT_PUBLIC_API_END_POINT;
 
 const BASE_HEADER = {
-  'Content-Type': 'application/json ;charset: utf-8',
+  'Content-Type': 'application/json; charset=utf-8',
 };
 
 export { BASE_URL, BASE_HEADER };

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -1,7 +1,7 @@
 const BASE_URL = process.env.NEXT_PUBLIC_API_END_POINT;
 
 const BASE_HEADER = {
-  'Content-Type': 'application/json',
+  'Content-Type': 'application/json ;charset: utf-8',
 };
 
 export { BASE_URL, BASE_HEADER };

--- a/src/constants/localStorageKey.ts
+++ b/src/constants/localStorageKey.ts
@@ -1,0 +1,3 @@
+const User = 'user';
+
+export { User };

--- a/src/constants/pagintaion.ts
+++ b/src/constants/pagintaion.ts
@@ -1,0 +1,3 @@
+const PER_PAGE = 10;
+
+export { PER_PAGE };

--- a/src/hooks/useUserFollow.ts
+++ b/src/hooks/useUserFollow.ts
@@ -1,0 +1,54 @@
+import { AuthorType } from '@/types/article';
+import { useState } from 'react';
+
+import { followUser, unFollowUser } from '@/api/profiles';
+
+const useUserFollow = (user: { following: boolean; name: string }) => {
+  const [response, setResponse] = useState<undefined | AuthorType>();
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [isError, setIsError] = useState(false);
+
+  const handleUserFollow = async () => {
+    if (user.following) {
+      try {
+        const response = await unFollowUser(user.name);
+        if (!response.ok) {
+          throw new Error('Failed to fetch profile');
+        }
+        return response.json();
+      } catch (error) {
+        console.error(error);
+        throw error;
+      }
+    } else {
+      try {
+        const response = await followUser(user.name);
+        if (!response.ok) {
+          throw new Error('Failed to fetch profile');
+        }
+        return response.json();
+      } catch (error) {
+        console.error(error);
+        throw error;
+      }
+    }
+  };
+
+  const handleSetFollow = async () => {
+    try {
+      setIsLoading(true);
+      setIsSuccess(false);
+      setIsError(false);
+      const data: AuthorType = await handleUserFollow();
+      setIsLoading(false);
+      setIsSuccess(true);
+      setResponse(data);
+    } catch (error) {
+      setIsError(true);
+    }
+  };
+  return { handleSetFollow, response, isLoading, isError, isSuccess };
+};
+
+export default useUserFollow;

--- a/src/pageComponents/Article/Article.tsx
+++ b/src/pageComponents/Article/Article.tsx
@@ -1,0 +1,44 @@
+import { ArticleType } from '@/types/article';
+
+import DayFormatter from '@/utils/dayFormat';
+
+interface ArticleProps {
+  article: ArticleType;
+}
+
+const Article = ({ article }: ArticleProps) => {
+  const { author } = article;
+  const dayFormatter = new DayFormatter(new Date(article.createdAt));
+  return (
+    <div className="article-preview">
+      <div className="article-meta">
+        <a href={`/@${author.username}`}>
+          <img src={author.image} />
+        </a>
+        <div className="info">
+          <a href={`/@${author.username}`} className="author">
+            {author.username}
+          </a>
+          <span className="date">{dayFormatter.getMonthDayYear()}</span>
+        </div>
+        <button className="btn btn-outline-primary btn-sm pull-xs-right">
+          <i className="ion-heart"></i> {article.favoritesCount}
+        </button>
+      </div>
+      <a href={`/article/${article.slug}`} className="preview-link">
+        <h1>{article.title}</h1>
+        <p>{article.description}</p>
+        <span>Read more...</span>
+        <ul className="tag-list">
+          {article.tagList.map((tag) => (
+            <li key={tag} className="tag-default tag-pill tag-outline">
+              {tag}
+            </li>
+          ))}
+        </ul>
+      </a>
+    </div>
+  );
+};
+
+export default Article;

--- a/src/pageComponents/Article/Article.tsx
+++ b/src/pageComponents/Article/Article.tsx
@@ -1,43 +1,99 @@
-import { ArticleType } from '@/types/article';
+import { ArticleType, FeedResponseType } from '@/types/article';
+import { useState } from 'react';
+
+import { favoriteUser, unFavoriteUser } from '@/api/article';
 
 import DayFormatter from '@/utils/dayFormat';
 
 interface ArticleProps {
   article: ArticleType;
+  setData: (data: FeedResponseType) => void;
 }
 
 const Article = ({ article }: ArticleProps) => {
-  const { author } = article;
   const dayFormatter = new DayFormatter(new Date(article.createdAt));
+  const [currentArticle, setCurrentArticle] = useState<ArticleType>(article);
+
+  const handleClickFavoriteButton = async (
+    isFavorite: boolean,
+    slug: string,
+  ) => {
+    if (isFavorite) {
+      const data = await cancelFavorite(slug);
+      console.log(data);
+      return setCurrentArticle(data);
+    }
+    if (!isFavorite) {
+      const data = await await addFavorite(slug);
+      console.log(data);
+      return setCurrentArticle(data);
+    }
+  };
+
+  const addFavorite = async (slug: string) => {
+    try {
+      const response = await favoriteUser(slug);
+      if (!response.ok) {
+        throw new Error('Failed to fetch profile');
+      }
+      return response.json();
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  };
+
+  const cancelFavorite = async (slug: string) => {
+    try {
+      const response = await unFavoriteUser(slug);
+      if (!response.ok) {
+        throw new Error('Failed to fetch profile');
+      }
+      return response.json();
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  };
+  console.log(currentArticle);
+
   return (
-    <div className="article-preview">
-      <div className="article-meta">
-        <a href={`/@${author.username}`}>
-          <img src={author.image} />
-        </a>
-        <div className="info">
-          <a href={`/@${author.username}`} className="author">
-            {author.username}
+    currentArticle && (
+      <div className="article-preview">
+        <div className="article-meta">
+          <a href={`/@${currentArticle.author.username}`}>
+            <img src={currentArticle.author.image} />
           </a>
-          <span className="date">{dayFormatter.getMonthDayYear()}</span>
+          <div className="info">
+            <a href={`/@${currentArticle.author.username}`} className="author">
+              {currentArticle.author.username}
+            </a>
+            <span className="date">{dayFormatter.getMonthDayYear()}</span>
+          </div>
+          <button
+            onClick={() =>
+              handleClickFavoriteButton(article.favorited, article.slug)
+            }
+            className="btn btn-outline-primary btn-sm pull-xs-right"
+          >
+            <i className="ion-heart"></i> {article.favoritesCount}
+          </button>
         </div>
-        <button className="btn btn-outline-primary btn-sm pull-xs-right">
-          <i className="ion-heart"></i> {article.favoritesCount}
-        </button>
+
+        <a href={`/article/${article.slug}`} className="preview-link">
+          <h1>{article.title}</h1>
+          <p>{article.description}</p>
+          <span>Read more...</span>
+          <ul className="tag-list">
+            {article.tagList.map((tag) => (
+              <li key={tag} className="tag-default tag-pill tag-outline">
+                {tag}
+              </li>
+            ))}
+          </ul>
+        </a>
       </div>
-      <a href={`/article/${article.slug}`} className="preview-link">
-        <h1>{article.title}</h1>
-        <p>{article.description}</p>
-        <span>Read more...</span>
-        <ul className="tag-list">
-          {article.tagList.map((tag) => (
-            <li key={tag} className="tag-default tag-pill tag-outline">
-              {tag}
-            </li>
-          ))}
-        </ul>
-      </a>
-    </div>
+    )
   );
 };
 

--- a/src/pageComponents/Articles/Articles.tsx
+++ b/src/pageComponents/Articles/Articles.tsx
@@ -1,17 +1,17 @@
-import { FeedResponseType } from '@/types/article';
+import { ArticleType } from '@/types/article';
 
 import Article from '../Article/Article';
 
 interface ArticlesProps {
-  articles: FeedResponseType;
+  articles: ArticleType[];
 }
 
 const Articles = ({ articles }: ArticlesProps) => {
-  if (articles?.articles.length === 0) {
+  if (articles?.length === 0) {
     return <div>피드가 없습니다...</div>;
   }
 
-  return articles.articles.map((article) => (
+  return articles.map((article) => (
     <Article key={article.slug} article={article} />
   ));
 };

--- a/src/pageComponents/Articles/Articles.tsx
+++ b/src/pageComponents/Articles/Articles.tsx
@@ -1,4 +1,4 @@
-import { ArticleType } from '@/types/article';
+import { ArticleType, FeedResponseType } from '@/types/article';
 
 import Article from '../Article/Article';
 

--- a/src/pageComponents/Articles/Articles.tsx
+++ b/src/pageComponents/Articles/Articles.tsx
@@ -1,0 +1,19 @@
+import { FeedResponseType } from '@/types/article';
+
+import Article from '../Article/Article';
+
+interface ArticlesProps {
+  articles: FeedResponseType;
+}
+
+const Articles = ({ articles }: ArticlesProps) => {
+  if (articles?.articles.length === 0) {
+    return <div>피드가 없습니다...</div>;
+  }
+
+  return articles.articles.map((article) => (
+    <Article key={article.slug} article={article} />
+  ));
+};
+
+export default Articles;

--- a/src/pageComponents/Navbar/Navbar.tsx
+++ b/src/pageComponents/Navbar/Navbar.tsx
@@ -12,21 +12,21 @@ const Navbar = () => {
   const pathname = usePathname();
 
   const PATH = [
-    { href: '/', title: 'Home', id: 'Home' },
-    { href: '/login', title: 'Sign in', id: 'Sign in' },
-    { href: '/signUp', title: 'Sign Up', id: 'Sign up' },
+    { href: '/', title: 'Home'},
+    { href: '/login', title: 'Sign in'},
+    { href: '/signUp', title: 'Sign Up'},
   ];
 
   return (
     <nav className="navbar navbar-light">
       <div className="container flex !justify-between">
-        <a className="navbar-brand" href="/">
+        <Link className="navbar-brand" href="/">
           Moseung
-        </a>
+        </Link>
         <ul className="flex gap-2">
           {PATH.map((path) => (
             <Link
-              key={path.id}
+              key={path.title}
               className={cn(
                 NavbarStyle({ isCurrentPath: pathname === path.href }),
               )}

--- a/src/pageComponents/Navbar/Navbar.tsx
+++ b/src/pageComponents/Navbar/Navbar.tsx
@@ -42,7 +42,7 @@ const Navbar = () => {
           Moseung
         </Link>
         <ul className="flex gap-2">
-          {(JSON.parse(window.localStorage.getItem('user'))?.username
+          {(JSON.parse(window.localStorage.getItem('user'))
             ? LOGIN_PATH
             : NOT_LOGIN_PATH
           ).map((path, index) => (

--- a/src/pageComponents/Navbar/Navbar.tsx
+++ b/src/pageComponents/Navbar/Navbar.tsx
@@ -10,7 +10,6 @@ import { NavbarStyle } from './style';
 
 const Navbar = () => {
   const pathname = usePathname();
-  const [userName, setUserName] = useState('');
 
   const NOT_LOGIN_PATH = [
     { href: '/', title: 'Home' },
@@ -31,14 +30,11 @@ const Navbar = () => {
     },
     { href: '/settings', title: 'settings' },
     {
-      href: `/@${userName}`,
-      title: userName,
+      href: `/@${JSON.parse(window.localStorage.getItem('user'))?.username}`,
+      title: JSON.parse(window.localStorage.getItem('user'))?.username,
     },
   ];
 
-  useEffect(() => {
-    setUserName(JSON.parse(window.localStorage.getItem('user'))?.username);
-  }, []);
   return (
     <nav className="navbar navbar-light">
       <div className="container flex !justify-between">
@@ -46,7 +42,10 @@ const Navbar = () => {
           Moseung
         </Link>
         <ul className="flex gap-2">
-          {(userName ? LOGIN_PATH : NOT_LOGIN_PATH).map((path, index) => (
+          {(JSON.parse(window.localStorage.getItem('user'))?.username
+            ? LOGIN_PATH
+            : NOT_LOGIN_PATH
+          ).map((path, index) => (
             <Link
               key={index}
               className={cn(

--- a/src/pageComponents/Navbar/Navbar.tsx
+++ b/src/pageComponents/Navbar/Navbar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { cn } from '@/utils/style';
 
@@ -10,13 +10,35 @@ import { NavbarStyle } from './style';
 
 const Navbar = () => {
   const pathname = usePathname();
+  const [userName, setUserName] = useState('');
 
-  const PATH = [
-    { href: '/', title: 'Home'},
-    { href: '/login', title: 'Sign in'},
-    { href: '/signUp', title: 'Sign Up'},
+  const NOT_LOGIN_PATH = [
+    { href: '/', title: 'Home' },
+    { href: '/login', title: 'Sign in' },
+    { href: '/signUp', title: 'Sign Up' },
   ];
 
+  const LOGIN_PATH = [
+    { href: '/', title: 'Home' },
+    {
+      href: '/editor',
+      title: (
+        <div>
+          <img src="" alt="" />
+          New Article
+        </div>
+      ),
+    },
+    { href: '/settings', title: 'settings' },
+    {
+      href: `/@${userName}`,
+      title: userName,
+    },
+  ];
+
+  useEffect(() => {
+    setUserName(JSON.parse(window.localStorage.getItem('user'))?.username);
+  }, []);
   return (
     <nav className="navbar navbar-light">
       <div className="container flex !justify-between">
@@ -24,9 +46,9 @@ const Navbar = () => {
           Moseung
         </Link>
         <ul className="flex gap-2">
-          {PATH.map((path) => (
+          {(userName ? LOGIN_PATH : NOT_LOGIN_PATH).map((path, index) => (
             <Link
-              key={path.title}
+              key={index}
               className={cn(
                 NavbarStyle({ isCurrentPath: pathname === path.href }),
               )}

--- a/src/pageComponents/Pagination/Paginaiton.tsx
+++ b/src/pageComponents/Pagination/Paginaiton.tsx
@@ -1,0 +1,47 @@
+import { Dispatch, SetStateAction } from 'react';
+
+import { cn } from '@/utils/style';
+
+import { PaginationStyle } from './style';
+
+interface PaginationProps {
+  totalPage: number;
+  limit: number;
+  offset?: number;
+  currentPage: number;
+  setCurrentPage: Dispatch<SetStateAction<number>>;
+}
+
+const Pagination = ({
+  totalPage,
+  currentPage,
+  offset = 10,
+  setCurrentPage,
+}: PaginationProps) => {
+  if (!totalPage) return;
+  return (
+    <ul className="pagination">
+      {totalPage &&
+        Array.from({ length: Math.ceil(totalPage / offset) }).map(
+          (_, index) => {
+            const syncWithCurrentPageIndex = index + 1;
+            return (
+              <li
+                key={syncWithCurrentPageIndex}
+                onClick={() => setCurrentPage(syncWithCurrentPageIndex)}
+                className={cn(
+                  PaginationStyle({
+                    isActive: syncWithCurrentPageIndex === currentPage,
+                  }),
+                )}
+              >
+                <p className="page-link">{syncWithCurrentPageIndex}</p>
+              </li>
+            );
+          },
+        )}
+    </ul>
+  );
+};
+
+export default Pagination;

--- a/src/pageComponents/Pagination/Paginaiton.tsx
+++ b/src/pageComponents/Pagination/Paginaiton.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/utils/style';
 import { PaginationStyle } from './style';
 
 interface PaginationProps {
-  totalPage: number;
+  totalPage: number | undefined;
   limit: number;
   offset?: number;
   currentPage: number;

--- a/src/pageComponents/Pagination/style.ts
+++ b/src/pageComponents/Pagination/style.ts
@@ -1,0 +1,11 @@
+import { cva } from 'class-variance-authority';
+
+const PaginationStyle = cva(['page-item', 'cursor-pointer'], {
+  variants: {
+    isActive: {
+      true: ['active'],
+    },
+  },
+});
+
+export { PaginationStyle };

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -1,13 +1,13 @@
-type ArticlePostRequestType = {
+interface ArticlePostRequestType {
   article: {
     title: string;
     description: string;
     body: string;
     tagList: string[];
   };
-};
+}
 
-type FeedResponseType = {
+interface FeedResponseType {
   articles: [
     {
       slug: string;
@@ -28,6 +28,6 @@ type FeedResponseType = {
     },
   ];
   articlesCount: number;
-};
+}
 
 export type { FeedResponseType, ArticlePostRequestType };

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -1,3 +1,12 @@
+type ArticlePostRequestType = {
+  article: {
+    title: string;
+    description: string;
+    body: string;
+    tagList: string[];
+  };
+};
+
 type FeedResponseType = {
   articles: [
     {
@@ -21,4 +30,4 @@ type FeedResponseType = {
   articlesCount: number;
 };
 
-export type { FeedResponseType };
+export type { FeedResponseType, ArticlePostRequestType };

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -1,24 +1,24 @@
-type GlobalFeedResponseType = {
+type FeedResponseType = {
   articles: [
     {
-      slug: 'string';
-      title: 'string';
-      description: 'string';
-      body: 'string';
-      tagList: ['string'];
-      createdAt: '2023-09-20T11:51:46.724Z';
-      updatedAt: '2023-09-20T11:51:46.724Z';
-      favorited: true;
-      favoritesCount: 0;
+      slug: string;
+      title: string;
+      description: string;
+      body: string;
+      tagList: string[];
+      createdAt: string;
+      updatedAt: string;
+      favorited: boolean;
+      favoritesCount: number;
       author: {
-        username: 'string';
-        bio: 'string';
-        image: 'string';
-        following: true;
+        username: string;
+        bio: string;
+        image: string;
+        following: boolean;
       };
     },
   ];
-  articlesCount: 0;
+  articlesCount: number;
 };
 
-export type { GlobalFeedResponseType };
+export type { FeedResponseType };

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -7,27 +7,26 @@ interface ArticlePostRequestType {
   };
 }
 
+type ArticleType = {
+  slug: string;
+  title: string;
+  description: string;
+  body: string;
+  tagList: string[];
+  createdAt: string;
+  updatedAt: string;
+  favorited: boolean;
+  favoritesCount: number;
+  author: {
+    username: string;
+    bio: string;
+    image: string;
+    following: boolean;
+  };
+};
 interface FeedResponseType {
-  articles: [
-    {
-      slug: string;
-      title: string;
-      description: string;
-      body: string;
-      tagList: string[];
-      createdAt: string;
-      updatedAt: string;
-      favorited: boolean;
-      favoritesCount: number;
-      author: {
-        username: string;
-        bio: string;
-        image: string;
-        following: boolean;
-      };
-    },
-  ];
+  articles: ArticleType[];
   articlesCount: number;
 }
 
-export type { FeedResponseType, ArticlePostRequestType };
+export type { FeedResponseType, ArticlePostRequestType, ArticleType };

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -7,7 +7,14 @@ interface ArticlePostRequestType {
   };
 }
 
-type ArticleType = {
+interface AuthorType {
+  username: string;
+  bio: string;
+  image: string;
+  following: boolean;
+}
+
+interface ArticleType {
   slug: string;
   title: string;
   description: string;
@@ -17,16 +24,16 @@ type ArticleType = {
   updatedAt: string;
   favorited: boolean;
   favoritesCount: number;
-  author: {
-    username: string;
-    bio: string;
-    image: string;
-    following: boolean;
-  };
-};
+  author: AuthorType;
+}
 interface FeedResponseType {
   articles: ArticleType[];
   articlesCount: number;
 }
 
-export type { FeedResponseType, ArticlePostRequestType, ArticleType };
+export type {
+  FeedResponseType,
+  ArticlePostRequestType,
+  ArticleType,
+  AuthorType,
+};

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -1,0 +1,24 @@
+type GlobalFeedResponseType = {
+  articles: [
+    {
+      slug: 'string';
+      title: 'string';
+      description: 'string';
+      body: 'string';
+      tagList: ['string'];
+      createdAt: '2023-09-20T11:51:46.724Z';
+      updatedAt: '2023-09-20T11:51:46.724Z';
+      favorited: true;
+      favoritesCount: 0;
+      author: {
+        username: 'string';
+        bio: 'string';
+        image: 'string';
+        following: true;
+      };
+    },
+  ];
+  articlesCount: 0;
+};
+
+export type { GlobalFeedResponseType };

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,35 +1,35 @@
 type LoginPostRequestType = {
   user: {
-    email: 'string';
-    password: 'string';
+    email: string;
+    password: string;
   };
 };
 
 type RegisterPostRequestType = {
   user: {
-    username: 'string';
-    email: 'string';
-    password: 'string';
+    username: string;
+    email: string;
+    password: string;
   };
 };
 
 type UpdatePutRequestType = {
   user: {
-    email: 'string';
-    password: 'string';
-    username: 'string';
-    bio: 'string';
-    image: 'string';
+    email: string;
+    password: string;
+    username: string;
+    bio: string;
+    image: string;
   };
 };
 
 type UsersResponseType = {
   user: {
-    email: 'string';
-    token: 'string';
-    username: 'string';
-    bio: 'string';
-    image: 'string';
+    email: string;
+    token: string;
+    username: string;
+    bio: string;
+    image: string;
   };
 };
 

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -13,7 +13,7 @@ type RegisterPostRequestType = {
   };
 };
 
-type UpdatePutRequestType = {
+type UpdateUserType = {
   user: {
     email: string;
     password: string;
@@ -23,7 +23,7 @@ type UpdatePutRequestType = {
   };
 };
 
-type UsersResponseType = {
+type UserType = {
   user: {
     email: string;
     token: string;
@@ -36,6 +36,6 @@ type UsersResponseType = {
 export type {
   LoginPostRequestType,
   RegisterPostRequestType,
-  UpdatePutRequestType,
-  UsersResponseType,
+  UpdateUserType,
+  UserType,
 };

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,19 +1,19 @@
-type LoginPostRequestType = {
+interface LoginPostRequestType {
   user: {
     email: string;
     password: string;
   };
-};
+}
 
-type RegisterPostRequestType = {
+interface RegisterPostRequestType {
   user: {
     username: string;
     email: string;
     password: string;
   };
-};
+}
 
-type UpdateUserType = {
+interface UpdateUserType {
   user: {
     email: string;
     password: string;
@@ -21,9 +21,9 @@ type UpdateUserType = {
     bio: string;
     image: string;
   };
-};
+}
 
-type UserType = {
+interface UserType {
   user: {
     email: string;
     token: string;
@@ -31,7 +31,7 @@ type UserType = {
     bio: string;
     image: string;
   };
-};
+}
 
 export type {
   LoginPostRequestType,

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,0 +1,10 @@
+interface ProfileResponseType {
+  profile: {
+    username: string;
+    bio: string;
+    image: string;
+    following: boolean;
+  };
+}
+
+export type { ProfileResponseType };

--- a/src/utils/browserStorage.ts
+++ b/src/utils/browserStorage.ts
@@ -1,0 +1,23 @@
+const LocalStorage = {
+  get(key: string): string | null {
+    return localStorage.getItem(key);
+  },
+
+  set(key: string, value: string) {
+    localStorage.setItem(key, value);
+  },
+
+  remove(key: string) {
+    localStorage.removeItem(key);
+  },
+
+  clear() {
+    localStorage.clear();
+  },
+};
+
+const ParseGetLocalStorage = (key: string) => {
+  JSON.parse(LocalStorage.get(key));
+};
+
+export { LocalStorage, ParseGetLocalStorage };

--- a/src/utils/browserStorage.ts
+++ b/src/utils/browserStorage.ts
@@ -1,18 +1,18 @@
 const LocalStorage = {
   get(key: string): string | null {
-    return localStorage.getItem(key);
+    return global.window.localStorage.getItem(key);
   },
 
   set(key: string, value: string) {
-    localStorage.setItem(key, value);
+    global.window.localStorage.setItem(key, value);
   },
 
   remove(key: string) {
-    localStorage.removeItem(key);
+    global.window.localStorage.removeItem(key);
   },
 
   clear() {
-    localStorage.clear();
+    global.window.localStorage.clear();
   },
 };
 

--- a/src/utils/dayFormat.ts
+++ b/src/utils/dayFormat.ts
@@ -6,6 +6,10 @@ class DayFormatter {
     this.date = date;
   }
 
+  getMonthDate() {
+    return dayjs(this.date).locale('en').format('MMMM Do');
+  }
+
   getMonthDayYear() {
     return dayjs(this.date).format('MMMM D, YYYY');
   }

--- a/src/utils/dayFormat.ts
+++ b/src/utils/dayFormat.ts
@@ -1,0 +1,14 @@
+import dayjs from 'dayjs';
+
+class DayFormatter {
+  date: Date;
+  constructor(date: Date) {
+    this.date = date;
+  }
+
+  getMonthDayYear() {
+    return dayjs(this.date).format('MMMM D, YYYY');
+  }
+}
+
+export default DayFormatter;


### PR DESCRIPTION
## 📖 작업 배경

- ProtectedRoute
- homePage
  - 탭 별로 화면 바뀜, 데이터 불러오기 구현
- Navbar
  - User 정보에 따라 내용 바뀜 구현
- settings
  - UI 구현
- 게시글 작성
  - 실제 값으로 게시물 추가까지 구현(해당 페이지로 이동은 구현 x)
- 마이페이지
  - UI 구현

<br/>

## 🛠️ 구현 내용

- routing 별로 권한을 주어 페이지 이동을 정리하였습니다.
- 유저 정보를 localStorage에 주기 싫음 + SSR에서도 유저 정보를 쓰고 싶어 cookie에 저장하여 http only를 설정하고 헤더에서 쿠키를 조회하여 값을 얻기위해 route handler, middleware 등등을 많이 적용해봤지만 구현하지 못해 일단 임시적으로 localStorage에 구현하였습니다 ..ㅠㅠ 이것때문에 10시간이상 쓴거같네요 그래서 구현을 잘 못했어요 죄송해요.
- 그 외에 특이사항은 없습니다. 구현 위주로 가느라 코드 질은 챙기지 못했습니다.

<br/>