### PR TITLE
feat(login): 로그인 화면에서 로그인 기능을 구현하고 정상 로그인 시 홈 페이지로 이동되도록 합니다.

### DIFF
--- a/apps/react-world/src/apis/login/LoginService.ts
+++ b/apps/react-world/src/apis/login/LoginService.ts
@@ -1,0 +1,25 @@
+import { isAxiosError } from 'axios';
+import { api } from '../apiInstances';
+import type { LoginUserParams, LoginUserResponse } from './LoginService.types';
+
+class LoginService {
+  static async loginUser(
+    userData: LoginUserParams,
+  ): Promise<LoginUserResponse> {
+    try {
+      const response = await api.post('/users/login', {
+        user: userData,
+      });
+      return response.data;
+    } catch (error) {
+      if (isAxiosError(error) && error.response) {
+        console.error('Axios error occurred:', error.response.data);
+        throw error.response.data;
+      }
+      console.error('An unexpected error occurred:', error);
+      throw error;
+    }
+  }
+}
+
+export default LoginService;

--- a/apps/react-world/src/apis/login/LoginService.types.ts
+++ b/apps/react-world/src/apis/login/LoginService.types.ts
@@ -1,6 +1,6 @@
 // LoginService.types.ts
 
-import type CurrentUser from '@appTypes/CurrentUser';
+import type CurrentUser from '@/app-types/CurrentUser';
 
 export interface LoginUserParams {
   email: string;

--- a/apps/react-world/src/apis/login/LoginService.types.ts
+++ b/apps/react-world/src/apis/login/LoginService.types.ts
@@ -1,0 +1,16 @@
+// LoginService.types.ts
+
+import type CurrentUser from '@appTypes/CurrentUser';
+
+export interface LoginUserParams {
+  email: string;
+  password: string;
+}
+
+export interface LoginUserErrors {
+  [key: string]: string[];
+}
+
+export interface LoginUserResponse {
+  user: CurrentUser & { jwtToken: string };
+}

--- a/apps/react-world/src/apis/register/RegisterService.types.ts
+++ b/apps/react-world/src/apis/register/RegisterService.types.ts
@@ -1,4 +1,4 @@
-import type CurrentUser from '@appTypes/CurrentUser';
+import type CurrentUser from '@/app-types/CurrentUser';
 
 export interface RegisterUserParams {
   username: string;

--- a/apps/react-world/src/apis/register/RegisterService.types.ts
+++ b/apps/react-world/src/apis/register/RegisterService.types.ts
@@ -1,3 +1,5 @@
+import type CurrentUser from '@appTypes/CurrentUser';
+
 export interface RegisterUserParams {
   username: string;
   email: string;
@@ -8,14 +10,6 @@ export interface RegisterUserErrors {
   [key: string]: string[];
 }
 
-export interface RegisteredUserResponse {
-  email: string;
-  token: string;
-  username: string;
-  bio: string | null;
-  image: string | null;
-}
-
 export interface RegisterUserResponse {
-  user: RegisteredUserResponse;
+  user: CurrentUser;
 }

--- a/apps/react-world/src/components/home/ArticlePreview.tsx
+++ b/apps/react-world/src/components/home/ArticlePreview.tsx
@@ -1,5 +1,5 @@
-import type { ArticlePreviewData } from '../../apis/article/ArticlePreviewService.types';
-import { formatDate } from '../../utils/dateUtils';
+import type { ArticlePreviewData } from '@/apis/article/ArticlePreviewService.types';
+import { formatDate } from '@/utils/dateUtils';
 import {
   ArticlePreviewContainer,
   ArticlePreviewMeta,

--- a/apps/react-world/src/components/home/HomeFeedContents.tsx
+++ b/apps/react-world/src/components/home/HomeFeedContents.tsx
@@ -6,11 +6,11 @@ import ArticlePreview from './ArticlePreview';
 import PopularArticleTagList from './PopularArticleTagList';
 import HomeFeedTab from './HomeFeedTab';
 import Pagination from './Pagination';
-import ArticleService from '../../apis/article/ArticleService';
-import useArticlePreviewQuery from '../../quries/useArticlePreviewQuery';
-import usePopularArticleTagsQuery from '../../quries/usePopularArticleTagsQuery';
-import { ARTICLE_PREVIEW_FETCH_LIMIT } from '../../apis/article/ArticlePreviewService';
-import { ARTICLE_DETAIL_CACHE_KEY } from '../../quries/useArticleDetailQuery';
+import ArticleService from '@/apis/article/ArticleService';
+import useArticlePreviewQuery from '@/quries/useArticlePreviewQuery';
+import usePopularArticleTagsQuery from '@/quries/usePopularArticleTagsQuery';
+import { ARTICLE_PREVIEW_FETCH_LIMIT } from '@/apis/article/ArticlePreviewService';
+import { ARTICLE_DETAIL_CACHE_KEY } from '@/quries/useArticleDetailQuery';
 
 type StandardFeedType = 'my' | 'global';
 type ArticleTagFeedType = string; // 아티클 태그는 어떤 문자열이든 가능

--- a/apps/react-world/src/components/login/LoginForm.styled.ts
+++ b/apps/react-world/src/components/login/LoginForm.styled.ts
@@ -6,3 +6,12 @@ export const LoginErrorMessage = styled.p`
   margin-left: 5px;
   font-size: 14px;
 `;
+
+export const StyledLoginButton = styled.button<{ disabled: boolean }>`
+  background-color: ${props => (props.disabled ? '#bbb' : '#5cb85c')};
+  border-color: ${props => (props.disabled ? '#bbb' : '#5cb85c')};
+  color: white;
+
+  cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
+  padding: 10px 20px; // 기본 버튼 패딩
+`;

--- a/apps/react-world/src/components/login/LoginForm.styled.ts
+++ b/apps/react-world/src/components/login/LoginForm.styled.ts
@@ -1,0 +1,8 @@
+import styled from '@emotion/styled';
+
+export const LoginErrorMessage = styled.p`
+  color: red;
+  margin-top: 5px;
+  margin-left: 5px;
+  font-size: 14px;
+`;

--- a/apps/react-world/src/components/login/LoginForm.tsx
+++ b/apps/react-world/src/components/login/LoginForm.tsx
@@ -3,6 +3,7 @@ import type { LoginStatus } from '@hooks/useLogin';
 import { useForm } from 'react-hook-form';
 import { LoginErrorMessage, StyledLoginButton } from './LoginForm.styled';
 import { type ReactNode } from 'react';
+import type { UserCredentials } from '@appTypes/UserCredentials';
 
 /*
 - ^로 시작합니다.
@@ -17,7 +18,7 @@ const EMAIL_REGEX = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i;
 interface LoginFormProps {
   loginError: LoginUserErrors | null;
   loginStatus: LoginStatus;
-  onLoginSubmit: (data: { email: string; password: string }) => void;
+  onLoginSubmit: (data: UserCredentials) => void;
 }
 
 const LoginForm = (props: LoginFormProps) => {

--- a/apps/react-world/src/components/login/LoginForm.tsx
+++ b/apps/react-world/src/components/login/LoginForm.tsx
@@ -1,9 +1,9 @@
-import type { LoginUserErrors } from '@apis/login/LoginService.types';
-import type { LoginStatus } from '@hooks/useLogin';
+import type { LoginUserErrors } from '@/apis/login/LoginService.types';
+import type { LoginStatus } from '@/hooks/useLogin';
 import { useForm } from 'react-hook-form';
 import { LoginErrorMessage, StyledLoginButton } from './LoginForm.styled';
 import { type ReactNode } from 'react';
-import type { UserCredentials } from '@appTypes/UserCredentials';
+import type { UserCredentials } from '@/app-types/UserCredentials';
 
 /*
 - ^로 시작합니다.

--- a/apps/react-world/src/components/login/LoginForm.tsx
+++ b/apps/react-world/src/components/login/LoginForm.tsx
@@ -1,5 +1,8 @@
-import styled from '@emotion/styled';
+import type { LoginUserErrors } from '@apis/login/LoginService.types';
+import type { LoginStatus } from '@hooks/useLogin';
 import { useForm } from 'react-hook-form';
+import { LoginErrorMessage, StyledLoginButton } from './LoginForm.styled';
+import { type ReactNode } from 'react';
 
 /*
 - ^로 시작합니다.
@@ -12,24 +15,24 @@ import { useForm } from 'react-hook-form';
 const EMAIL_REGEX = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i;
 
 interface LoginFormProps {
+  loginError: LoginUserErrors | null;
+  loginStatus: LoginStatus;
   onLoginSubmit: (data: { email: string; password: string }) => void;
 }
 
 const LoginForm = (props: LoginFormProps) => {
-  const { onLoginSubmit } = props;
+  const { loginError, loginStatus, onLoginSubmit } = props;
   const { register, handleSubmit, formState } = useForm<{
     email: string;
     password: string;
   }>();
   const { errors } = formState;
 
-  const onSubmit = (data: { email: string; password: string }) => {
-    console.log('onSubmit: ' + JSON.stringify(data, null, 2));
-    onLoginSubmit(data);
-  };
+  const shouldLoginButtonDisabled = loginStatus === 'loggingIn';
+  const buttonText = loginStatus === 'loggingIn' ? 'Signing in...' : 'Sign in';
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form onSubmit={handleSubmit(onLoginSubmit)}>
       <fieldset className="form-group">
         <input
           {...register('email', {
@@ -73,10 +76,28 @@ const LoginForm = (props: LoginFormProps) => {
           <LoginErrorMessage>{errors.password.message}</LoginErrorMessage>
         )}
       </fieldset>
-      <button type="submit" className="btn btn-lg btn-primary pull-xs-right">
-        Sign in
-      </button>
+      <LoginButton disabled={shouldLoginButtonDisabled}>
+        {buttonText}
+      </LoginButton>
     </form>
+  );
+};
+
+interface LoginButtonProps {
+  disabled: boolean;
+  children?: ReactNode;
+}
+const LoginButton = (props: LoginButtonProps) => {
+  const { disabled, children } = props;
+
+  return (
+    <StyledLoginButton
+      type="submit"
+      className={`btn btn-lg pull-xs-right`}
+      disabled={disabled}
+    >
+      {children}
+    </StyledLoginButton>
   );
 };
 

--- a/apps/react-world/src/components/login/LoginForm.tsx
+++ b/apps/react-world/src/components/login/LoginForm.tsx
@@ -80,11 +80,4 @@ const LoginForm = (props: LoginFormProps) => {
   );
 };
 
-const LoginErrorMessage = styled.p`
-  color: red;
-  margin-top: 5px;
-  margin-left: 5px;
-  font-size: 14px;
-`;
-
 export default LoginForm;

--- a/apps/react-world/src/components/login/LoginForm.tsx
+++ b/apps/react-world/src/components/login/LoginForm.tsx
@@ -91,18 +91,19 @@ const LoginForm = (props: LoginFormProps) => {
   );
 };
 
-interface LoginButtonProps {
-  disabled: boolean;
+interface LoginButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children?: ReactNode;
 }
 const LoginButton = (props: LoginButtonProps) => {
-  const { disabled, children } = props;
+  const { disabled = false, children, ...restProps } = props;
 
   return (
     <StyledLoginButton
       type="submit"
       className={`btn btn-lg pull-xs-right`}
       disabled={disabled}
+      {...restProps}
     >
       {children}
     </StyledLoginButton>

--- a/apps/react-world/src/components/login/LoginForm.tsx
+++ b/apps/react-world/src/components/login/LoginForm.tsx
@@ -76,6 +76,13 @@ const LoginForm = (props: LoginFormProps) => {
           <LoginErrorMessage>{errors.password.message}</LoginErrorMessage>
         )}
       </fieldset>
+      {loginError && (
+        <LoginErrorMessage>
+          {Object.entries(loginError)
+            .map(([key, value]) => `${key} ${value[0]}`)
+            .join('. ')}
+        </LoginErrorMessage>
+      )}
       <LoginButton disabled={shouldLoginButtonDisabled}>
         {buttonText}
       </LoginButton>

--- a/apps/react-world/src/components/login/LoginPageContainer.tsx
+++ b/apps/react-world/src/components/login/LoginPageContainer.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import LoginForm from './LoginForm';
 import LoginHeader from './LoginHeader';
-import useLogin from '@hooks/useLogin';
+import useLogin from '@/hooks/useLogin';
 
 const LoginPageContainer = () => {
   const { loginError, loginStatus, handleLogin } = useLogin();

--- a/apps/react-world/src/components/login/LoginPageContainer.tsx
+++ b/apps/react-world/src/components/login/LoginPageContainer.tsx
@@ -1,10 +1,9 @@
 import LoginForm from './LoginForm';
 import LoginHeader from './LoginHeader';
+import useLogin from '@hooks/useLogin';
 
 const LoginPageContainer = () => {
-  const handleLogin = (data: { email: string; password: string }) => {
-    console.log('handleLogin: ' + JSON.stringify(data, null, 2));
-  };
+  const { loginError, loginStatus, handleLogin } = useLogin();
 
   return (
     <div className="auth-page">
@@ -12,7 +11,11 @@ const LoginPageContainer = () => {
         <div className="row">
           <div className="col-md-6 offset-md-3 col-xs-12">
             <LoginHeader />
-            <LoginForm onLoginSubmit={handleLogin} />
+            <LoginForm
+              loginError={loginError}
+              loginStatus={loginStatus}
+              onLoginSubmit={handleLogin}
+            />
           </div>
         </div>
       </div>

--- a/apps/react-world/src/components/login/LoginPageContainer.tsx
+++ b/apps/react-world/src/components/login/LoginPageContainer.tsx
@@ -1,9 +1,18 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import LoginForm from './LoginForm';
 import LoginHeader from './LoginHeader';
 import useLogin from '@hooks/useLogin';
 
 const LoginPageContainer = () => {
   const { loginError, loginStatus, handleLogin } = useLogin();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (loginStatus === 'success') {
+      navigate('/'); // 홈페이지로 리다이렉트
+    }
+  }, [loginStatus, navigate]);
 
   return (
     <div className="auth-page">

--- a/apps/react-world/src/components/shared/NavBar/NavBarBrand.tsx
+++ b/apps/react-world/src/components/shared/NavBar/NavBarBrand.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 
 export const NavbarBrand = () => {

--- a/apps/react-world/src/hooks/useLogin.ts
+++ b/apps/react-world/src/hooks/useLogin.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { LoginUserErrors } from '../apis/login/LoginService.types'; // 로그인 관련 타입으로 수정
 import LoginService from '../apis/login/LoginService'; // LoginService로 수정
 import { saveTokenToCookie } from '@utils/jwtUtils';
+import type { UserCredentials } from '@appTypes/UserCredentials';
 
 export type LoginStatus = 'idle' | 'loggingIn' | 'success' | 'failed';
 
@@ -9,7 +10,7 @@ const useLogin = () => {
   const [loginError, setLoginError] = useState<LoginUserErrors | null>(null);
   const [loginStatus, setLoginStatus] = useState<LoginStatus>('idle');
 
-  const handleLogin = async (data: { email: string; password: string }) => {
+  const handleLogin = async (data: UserCredentials) => {
     try {
       setLoginStatus('loggingIn');
       const response = await LoginService.loginUser(data);

--- a/apps/react-world/src/hooks/useLogin.ts
+++ b/apps/react-world/src/hooks/useLogin.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useReducer } from 'react';
 import type { LoginUserErrors } from '@/apis/login/LoginService.types'; // 로그인 관련 타입으로 수정
 import LoginService from '@/apis/login/LoginService'; // LoginService로 수정
 import { saveTokenToCookie } from '@/utils/jwtUtils';
@@ -6,36 +6,68 @@ import type { UserCredentials } from '@/app-types/UserCredentials';
 
 export type LoginStatus = 'idle' | 'loggingIn' | 'success' | 'failed';
 
+type LoginState = {
+  loginError: LoginUserErrors | null;
+  loginStatus: LoginStatus;
+};
+
+type LoginAction =
+  | { type: 'LOGIN_START' }
+  | { type: 'LOGIN_SUCCESS'; token: string }
+  | { type: 'LOGIN_ERROR'; error: LoginUserErrors }
+  | { type: 'LOGIN_FAILED' };
+
+const loginReducer = (state: LoginState, action: LoginAction): LoginState => {
+  switch (action.type) {
+    case 'LOGIN_START':
+      return { ...state, loginStatus: 'loggingIn', loginError: null };
+    case 'LOGIN_SUCCESS':
+      return { ...state, loginStatus: 'success', loginError: null };
+    case 'LOGIN_ERROR':
+      return { ...state, loginStatus: 'failed', loginError: action.error };
+    case 'LOGIN_FAILED':
+      return { ...state, loginStatus: 'failed' };
+    default:
+      return state;
+  }
+};
+
 const useLogin = () => {
-  const [loginError, setLoginError] = useState<LoginUserErrors | null>(null);
-  const [loginStatus, setLoginStatus] = useState<LoginStatus>('idle');
+  const [state, dispatch] = useReducer(loginReducer, {
+    loginError: null,
+    loginStatus: 'idle',
+  });
 
   const handleLogin = async (data: UserCredentials) => {
+    dispatch({ type: 'LOGIN_START' });
+
     try {
-      setLoginStatus('loggingIn');
       const response = await LoginService.loginUser(data);
       // JWT 토큰을 쿠키에 저장
       if (response && response.user && response.user.token) {
         saveTokenToCookie(response.user.token);
+        dispatch({ type: 'LOGIN_SUCCESS', token: response.user.token });
+        console.log('login suceess');
       }
-      setLoginStatus('success');
-      console.log('login suceess');
       return response;
     } catch (error) {
       if (error && typeof error === 'object' && 'errors' in error) {
-        setLoginError(error.errors as LoginUserErrors);
+        dispatch({
+          type: 'LOGIN_ERROR',
+          error: error.errors as LoginUserErrors,
+        });
         console.error('LoginUserErrors: ', error.errors);
       } else {
+        dispatch({ type: 'LOGIN_FAILED' });
         console.error('An unexpected error occurred:', error);
       }
-      setLoginStatus('failed');
       return null;
     }
   };
 
   return {
-    loginError,
-    loginStatus,
+    loginError: state.loginError,
+    loginStatus: state.loginStatus,
     handleLogin,
   };
 };

--- a/apps/react-world/src/hooks/useLogin.ts
+++ b/apps/react-world/src/hooks/useLogin.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import type { LoginUserErrors } from '../apis/login/LoginService.types'; // 로그인 관련 타입으로 수정
-import LoginService from '../apis/login/LoginService'; // LoginService로 수정
+import type { LoginUserErrors } from '@/apis/login/LoginService.types'; // 로그인 관련 타입으로 수정
+import LoginService from '@/apis/login/LoginService'; // LoginService로 수정
 import { saveTokenToCookie } from '@/utils/jwtUtils';
 import type { UserCredentials } from '@/app-types/UserCredentials';
 

--- a/apps/react-world/src/hooks/useLogin.ts
+++ b/apps/react-world/src/hooks/useLogin.ts
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import type { LoginUserErrors } from '../apis/login/LoginService.types'; // 로그인 관련 타입으로 수정
 import LoginService from '../apis/login/LoginService'; // LoginService로 수정
-import { saveTokenToCookie } from '@utils/jwtUtils';
-import type { UserCredentials } from '@appTypes/UserCredentials';
+import { saveTokenToCookie } from '@/utils/jwtUtils';
+import type { UserCredentials } from '@/app-types/UserCredentials';
 
 export type LoginStatus = 'idle' | 'loggingIn' | 'success' | 'failed';
 

--- a/apps/react-world/src/hooks/useLogin.ts
+++ b/apps/react-world/src/hooks/useLogin.ts
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import type { LoginUserErrors } from '../apis/login/LoginService.types'; // 로그인 관련 타입으로 수정
+import LoginService from '../apis/login/LoginService'; // LoginService로 수정
+import { saveTokenToCookie } from '@utils/jwtUtils';
+
+export type LoginStatus = 'idle' | 'loggingIn' | 'success' | 'failed';
+
+const useLogin = () => {
+  const [loginError, setLoginError] = useState<LoginUserErrors | null>(null);
+  const [loginStatus, setLoginStatus] = useState<LoginStatus>('idle');
+
+  const handleLogin = async (data: { email: string; password: string }) => {
+    try {
+      setLoginStatus('loggingIn');
+      const response = await LoginService.loginUser(data);
+      // JWT 토큰을 쿠키에 저장
+      if (response && response.user && response.user.token) {
+        saveTokenToCookie(response.user.token);
+      }
+      setLoginStatus('success');
+      console.log('login suceess');
+      return response;
+    } catch (error) {
+      if (error && typeof error === 'object' && 'errors' in error) {
+        setLoginError(error.errors as LoginUserErrors);
+        console.error('LoginUserErrors: ', error.errors);
+      } else {
+        console.error('An unexpected error occurred:', error);
+      }
+      setLoginStatus('failed');
+      return null;
+    }
+  };
+
+  return {
+    loginError,
+    loginStatus,
+    handleLogin,
+  };
+};
+
+export default useLogin;

--- a/apps/react-world/src/hooks/useRegister.ts
+++ b/apps/react-world/src/hooks/useRegister.ts
@@ -3,8 +3,8 @@ import type {
   RegisterUserErrors,
   RegisterUserParams,
   RegisterUserResponse,
-} from '../apis/register/RegisterService.types';
-import RegisterService from '../apis/register/RegisterService';
+} from '@/apis/register/RegisterService.types';
+import RegisterService from '@/apis/register/RegisterService';
 import { saveTokenToCookie } from '@/utils/jwtUtils';
 
 const useRegister = () => {

--- a/apps/react-world/src/pages/article.tsx
+++ b/apps/react-world/src/pages/article.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom';
-import ArticlePageContainer from '../components/article/ArticlePageContainer';
+import ArticlePageContainer from '@/components/article/ArticlePageContainer';
 
 export const ArticlePage = () => {
   const { articleSlug } = useParams<{ articleSlug: string }>() as {

--- a/apps/react-world/src/pages/login.tsx
+++ b/apps/react-world/src/pages/login.tsx
@@ -1,4 +1,4 @@
-import LoginPageContainer from '@components/login/LoginPageContainer';
+import LoginPageContainer from '@/components/login/LoginPageContainer';
 
 export const LoginPage = () => {
   return <LoginPageContainer></LoginPageContainer>;

--- a/apps/react-world/src/pages/register.tsx
+++ b/apps/react-world/src/pages/register.tsx
@@ -1,4 +1,4 @@
-import useRegister from '../hooks/useRegister';
+import useRegister from '@/hooks/useRegister';
 
 export const RegisterPage = () => {
   const { userData, error, isLoading, handleInputChange, handleSubmit } =

--- a/apps/react-world/src/quries/useArticleDetailQuery.ts
+++ b/apps/react-world/src/quries/useArticleDetailQuery.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import ArticleService from '../apis/article/ArticleService';
-import type { ArticleDetailResponse } from '../apis/article/ArticleService.types';
+import ArticleService from '@/apis/article/ArticleService';
+import type { ArticleDetailResponse } from '@/apis/article/ArticleService.types';
 
 export const ARTICLE_DETAIL_CACHE_KEY = '@article/detail';
 

--- a/apps/react-world/src/quries/useArticlePreviewQuery.ts
+++ b/apps/react-world/src/quries/useArticlePreviewQuery.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import ArticlePreviewService from '../apis/article/ArticlePreviewService';
+import ArticlePreviewService from '@/apis/article/ArticlePreviewService';
 
 export const ARTICLE_PREVIEW_CACHE_KEY = '@article/preview';
 

--- a/apps/react-world/src/quries/usePopularArticleTagsQuery.ts
+++ b/apps/react-world/src/quries/usePopularArticleTagsQuery.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import PopularArticleTagService from '../apis/article/PopularArticleTagService';
+import PopularArticleTagService from '@/apis/article/PopularArticleTagService';
 
 export const POPULAR_ARTICLE_TAG_CACHE_KEY = '@article/popular_tags';
 

--- a/apps/react-world/src/types/CurrentUser.ts
+++ b/apps/react-world/src/types/CurrentUser.ts
@@ -1,0 +1,9 @@
+interface CurrentUser {
+  email: string;
+  token: string;
+  username: string;
+  bio: string | null;
+  image: string | null;
+}
+
+export default CurrentUser;

--- a/apps/react-world/src/types/UserCredentials.ts
+++ b/apps/react-world/src/types/UserCredentials.ts
@@ -1,0 +1,4 @@
+export type UserCredentials = {
+  email: string;
+  password: string;
+};


### PR DESCRIPTION
## 📌 이슈 링크
- close #127


<br/>

## 📖 작업 배경

- #150 에서 로그인 폼의 UI 단 기능까지 어느정도 개발을 했고, 이번 PR에서는 실제 API 연동 기능을 개발합니다.

<br/>

## 🛠️ 구현 내용

- 회원 가입과 로그인에 둘 다 사용되는 응답 CurrentUser 를 새 타입으로 선언하고 기존 타입을 제거합니다.
- LoginService 와 useLogin 을 작성합니다. 훅에는 로그인 성공시 JWT 토큰을 갱신하는 로직도 포함되어 있습니다.
- 로그인 폼에서 로그인 상태를 전달받아 그에 따른 버튼 상태 변경 등을 UI를 개선했습니다.
- 로그인 버튼을 눌러 로그인을 시도할 때, 실제로 로그인을 진행하도록 합니다. (로그인 페이지 컨테이너에서 처리)
- 로그인에 성공하면 홈 화면으로 리다이렉트되도록 합니다. 기본 쿼리 파라미터를 붙여줄까 했지만 어차피 홈에서 알아서 처리를 해 주기에 그냥 Path 만 지정했습니다.
- 로그인에 실패할 때에는 그 이유를 할 수 있도록 폼 쪽에 간단히 에러 메시지 컴포넌트를 붙여 에러를 표시하도록 해 주었습니다.

<br/>

## 💡 참고사항

- 최근 드는 고민인데, login.tsx 에서는 아무 역할도 하지 않고 LoginContainer 에서 모든 역할을 다 하고 있는데, 지금 생각해보면 컨테이너에서는 렌더링에 관련된 역할까지만 하고 최상위 컴포넌트에서 비즈니스 로직과 관련된 모든 처리를 하는게 맞는 방향인건가? 하는 생각이 드네요. 이건 기회가 될 때 다른 개발자 분들께 Best Practice 를 여쭤 보려고 합니다.

<br/>

## 🖼️ 스크린샷

https://github.com/pagers-org/react-world/assets/2222333/33532d73-8d36-459a-ac93-8f4616a5c463

