### PR TITLE
feat: Comments/Favorites/Tags 구현 및 기존 코드 리팩토링

### DIFF
--- a/src/api/articles.ts
+++ b/src/api/articles.ts
@@ -142,7 +142,7 @@ export const getGlobalFeeds = ({
 };
 
 // Get an article (Auth Optional)
-export const getArticle = ({
+export const getArticle = async ({
   slug,
   headers = {},
   options = {},
@@ -150,18 +150,11 @@ export const getArticle = ({
   slug: string;
   headers?: HeadersInit;
   options?: RequestInit;
-}): Promise<FeedResponse | void> => {
-  return httpClient
+}): Promise<FeedResponse> => {
+  return await httpClient
     .get(`/articles/${slug}`, {
       ...options,
       headers,
     })
-    .then((res) => res.json())
-    .then((res: FeedResponse) => {
-      if (res?.errors || res?.status === 'error') {
-        throw new Error(ERROR.ARTICLE_DETAIL);
-      }
-      return res;
-    })
-    .catch((err) => console.error(err));
+    .then((res) => res.json());
 };

--- a/src/api/articles.ts
+++ b/src/api/articles.ts
@@ -15,8 +15,6 @@ import { getCookie } from '@/utils/cookie';
 
 import { httpClient } from './http/httpClient';
 
-/* Client Side APIs */
-
 // Create an article (Auth Required)
 export const postArticle = ({
   payload,
@@ -93,10 +91,6 @@ export const deleteArticle = ({
     .catch((err) => console.error(err));
 };
 
-// -----------------------------------------------------------------------------------------------------
-
-/* Server Side APIs for Next 13 APP Router extended fetch api */
-
 // Get recent articles from users you follow (Auth Required)
 export const getMyFeeds = ({
   queryStrings = {
@@ -109,12 +103,16 @@ export const getMyFeeds = ({
   headers?: HeadersInit;
   options?: RequestInit;
 }): Promise<FeedsResponse> => {
+  const accessToken = getCookie(COOKIE_ACCESS_TOKEN_KEY);
   const qs = new URLSearchParams(queryStrings).toString();
 
   return httpClient
     .get(`/articles/feed?${qs}`, {
       ...options,
-      headers,
+      headers: {
+        ...headers,
+        Authorization: `Bearer ${accessToken}`,
+      },
     })
     .then((res) => res.json())
     .catch((err) => console.error(err));

--- a/src/api/comments.ts
+++ b/src/api/comments.ts
@@ -1,0 +1,83 @@
+import {
+  CommentPayload,
+  CommentResponse,
+  CommentsResponse,
+} from '@/types/api/comments';
+
+import { COOKIE_ACCESS_TOKEN_KEY } from '@/constants/key';
+
+import { getCookie } from '@/utils/cookie';
+
+import { httpClient } from './http/httpClient';
+
+// Get comments for an article (Auth Optional)
+export const getComments = ({
+  slug,
+  headers = {},
+  options = {},
+}: {
+  slug: string;
+  headers?: HeadersInit;
+  options?: RequestInit;
+}): Promise<CommentsResponse> => {
+  return httpClient
+    .get(`/articles/${slug}/comments`, {
+      ...options,
+      headers,
+    })
+    .then((res) => res.json())
+    .catch((err) => console.error(err));
+};
+
+// Create a comment for an article (Auth Required)
+export const postComment = ({
+  slug,
+  payload,
+  headers = {},
+  options = {},
+}: {
+  slug: string;
+  payload: CommentPayload;
+  headers?: HeadersInit;
+  options?: RequestInit;
+}): Promise<CommentResponse> => {
+  const accessToken = getCookie(COOKIE_ACCESS_TOKEN_KEY);
+
+  return httpClient
+    .post(`/articles/${slug}/comments`, {
+      ...options,
+      headers: {
+        ...headers,
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify(payload),
+    })
+    .then((res) => res.json())
+    .catch((err) => console.error(err));
+};
+
+// Delete a comment for an article (Auth Required)
+export const deleteComment = ({
+  slug,
+  id,
+  headers = {},
+  options = {},
+}: {
+  slug: string;
+  id: number;
+  headers?: HeadersInit;
+  options?: RequestInit;
+}) => {
+  const accessToken = getCookie(COOKIE_ACCESS_TOKEN_KEY);
+
+  return httpClient
+    .delete(`/articles/${slug}/comments/${id}`, {
+      ...options,
+      headers: {
+        ...headers,
+        Authorization: `Bearer ${accessToken}`,
+      },
+    })
+    .then((res) => res.json())
+    .catch((err) => console.error(err));
+};

--- a/src/api/favorites.ts
+++ b/src/api/favorites.ts
@@ -1,0 +1,55 @@
+import { FavoritesResponse } from '@/types/api/favorites';
+
+import { COOKIE_ACCESS_TOKEN_KEY } from '@/constants/key';
+
+import { getCookie } from '@/utils/cookie';
+
+import { httpClient } from './http/httpClient';
+
+// Favorites an article (Auth Required)
+export const postFavorite = ({
+  slug,
+  headers = {},
+  options = {},
+}: {
+  slug: string;
+  headers?: HeadersInit;
+  options?: RequestInit;
+}): Promise<FavoritesResponse> => {
+  const accessToken = getCookie(COOKIE_ACCESS_TOKEN_KEY);
+
+  return httpClient
+    .post(`/articles/${slug}/favorite`, {
+      ...options,
+      headers: {
+        ...headers,
+        Authorization: `Bearer ${accessToken}`,
+      },
+    })
+    .then((res) => res.json())
+    .catch((err) => console.error(err));
+};
+
+// Unfavorite an article (Auth Required)
+export const deleteFavorite = ({
+  slug,
+  headers = {},
+  options = {},
+}: {
+  slug: string;
+  headers?: HeadersInit;
+  options?: RequestInit;
+}): Promise<FavoritesResponse> => {
+  const accessToken = getCookie(COOKIE_ACCESS_TOKEN_KEY);
+
+  return httpClient
+    .delete(`/articles/${slug}/favorite`, {
+      ...options,
+      headers: {
+        ...headers,
+        Authorization: `Bearer ${accessToken}`,
+      },
+    })
+    .then((res) => res.json())
+    .catch((err) => console.error(err));
+};

--- a/src/api/tags.ts
+++ b/src/api/tags.ts
@@ -1,0 +1,20 @@
+import { TagsResponse } from '@/types/api/tags';
+
+import { httpClient } from './http/httpClient';
+
+// Get tags (Auth Optional)
+export const getTags = ({
+  headers = {},
+  options = {},
+}: {
+  headers?: HeadersInit;
+  options?: RequestInit;
+}): Promise<TagsResponse> => {
+  return httpClient
+    .get(`/tags`, {
+      ...options,
+      headers,
+    })
+    .then((res) => res.json())
+    .catch((err) => console.error(err));
+};

--- a/src/app/article/[slug]/page.tsx
+++ b/src/app/article/[slug]/page.tsx
@@ -1,9 +1,9 @@
-import { FeedResponse } from '@/types/api/articles';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
 import ArticleDetailPageMain from '@/pageComponents/article/[slug]/ArticleDetailPageMain';
 
+import { ERROR } from '@/constants/error';
 import { COOKIE_ACCESS_TOKEN_KEY } from '@/constants/key';
 
 import { getArticle } from '@/api/articles';
@@ -13,12 +13,17 @@ const getArticleDetail = async (slug: string) => {
     const cookieStore = cookies();
     const accessToken = cookieStore.get(COOKIE_ACCESS_TOKEN_KEY)?.value;
 
-    const res = (await getArticle({
+    const res = await getArticle({
       slug,
       headers: {
         ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
       },
-    })) as FeedResponse;
+    });
+
+    if (res?.errors || res?.status === 'error') {
+      throw new Error(ERROR.ARTICLE_DETAIL);
+    }
+
     return res.article;
   } catch (e) {
     redirect('/');

--- a/src/app/article/[slug]/page.tsx
+++ b/src/app/article/[slug]/page.tsx
@@ -1,13 +1,24 @@
 import { FeedResponse } from '@/types/api/articles';
+import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
 import ArticleDetailPageMain from '@/pageComponents/article/[slug]/ArticleDetailPageMain';
+
+import { COOKIE_ACCESS_TOKEN_KEY } from '@/constants/key';
 
 import { getArticle } from '@/api/articles';
 
 const getArticleDetail = async (slug: string) => {
   try {
-    const res = (await getArticle({ slug })) as FeedResponse;
+    const cookieStore = cookies();
+    const accessToken = cookieStore.get(COOKIE_ACCESS_TOKEN_KEY)?.value;
+
+    const res = (await getArticle({
+      slug,
+      headers: {
+        ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
+      },
+    })) as FeedResponse;
     return res.article;
   } catch (e) {
     redirect('/');

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -1,9 +1,9 @@
-import { FeedResponse } from '@/types/api/articles';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
 import EditorPageMain from '@/pageComponents/editor/EditorPageMain';
 
+import { ERROR } from '@/constants/error';
 import { COOKIE_ACCESS_TOKEN_KEY } from '@/constants/key';
 
 import { getArticle } from '@/api/articles';
@@ -20,12 +20,16 @@ const getArticleDetail = async (slug: string) => {
     const cookieStore = cookies();
     const accessToken = cookieStore.get(COOKIE_ACCESS_TOKEN_KEY)?.value;
 
-    const res = (await getArticle({
+    const res = await getArticle({
       slug,
       headers: {
         Authorization: `Bearer ${accessToken}`,
       },
-    })) as FeedResponse;
+    });
+
+    if (res?.errors || res?.status === 'error') {
+      throw new Error(ERROR.ARTICLE_DETAIL);
+    }
 
     return res.article;
   } catch (e) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,45 +1,7 @@
-import { cookies } from 'next/headers';
-
 import HomePageMain from '@/pageComponents/HomePageMain';
 
-import { FEED_PER_PAGE, INITIAL_PAGE } from '@/constants/api';
-import { COOKIE_ACCESS_TOKEN_KEY } from '@/constants/key';
-
-import { getGlobalFeeds, getMyFeeds } from '@/api/articles';
-
-const getFeeds = async (page: string, perPage: string) => {
-  const cookieStore = cookies();
-  const accessToken = cookieStore.get(COOKIE_ACCESS_TOKEN_KEY)?.value;
-
-  const getFn = accessToken ? getMyFeeds : getGlobalFeeds;
-
-  const offset = ((parseInt(page) - 1) * parseInt(perPage)).toString();
-  const limit = perPage;
-
-  const res = await getFn({
-    queryStrings: {
-      offset,
-      limit,
-    },
-    headers: {
-      ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
-    },
-  });
-
-  return res;
-};
-
-const HomePage = async ({
-  searchParams,
-}: {
-  searchParams: Record<string, string | string[] | undefined>;
-}) => {
-  const feeds = await getFeeds(
-    (searchParams?.page as string) ?? INITIAL_PAGE,
-    (searchParams?.perPage as string) ?? FEED_PER_PAGE,
-  );
-
-  return <HomePageMain feeds={feeds} />;
+const HomePage = () => {
+  return <HomePageMain />;
 };
 
 export default HomePage;

--- a/src/hooks/query/articles/useArticlesQuery.ts
+++ b/src/hooks/query/articles/useArticlesQuery.ts
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { FEED_PER_PAGE } from '@/constants/api';
 
-import { getGlobalFeeds } from '@/api/articles';
+import { getGlobalFeeds, getMyFeeds } from '@/api/articles';
 
 export const useArticlesQuery = ({
   queryStrings = {
@@ -19,6 +19,24 @@ export const useArticlesQuery = ({
 }) => {
   const query = useQuery([queryKeys.GetArticles, queryStrings], () =>
     getGlobalFeeds({ queryStrings, headers, options }),
+  );
+
+  return query;
+};
+
+export const useMyFeedArticlesQuery = ({
+  queryStrings = {
+    limit: FEED_PER_PAGE,
+  },
+  headers = {},
+  options = {},
+}: {
+  queryStrings?: FeedQueryStrings;
+  headers?: HeadersInit;
+  options?: RequestInit;
+}) => {
+  const query = useQuery([queryKeys.GetMyFeedArticles, queryStrings], () =>
+    getMyFeeds({ queryStrings, headers, options }),
   );
 
   return query;

--- a/src/hooks/query/comments/useCommentsMutation.ts
+++ b/src/hooks/query/comments/useCommentsMutation.ts
@@ -1,21 +1,20 @@
-import { queryClient } from '@/react-query/queryClient';
 import { queryKeys } from '@/react-query/queryKeys';
 import { useMutation } from '@tanstack/react-query';
 
 import { deleteComment, postComment } from '@/api/comments';
 
-export const usePostCommentMutation = () => {
-  const mutation = useMutation([queryKeys.PostComment], postComment, {
-    onSuccess: () => queryClient.invalidateQueries([queryKeys.GetComments]),
-  });
+export const usePostCommentMutation = (options = {}) => {
+  const mutation = useMutation([queryKeys.PostComment], postComment, options);
 
   return mutation;
 };
 
-export const useDeleteCommentMutation = () => {
-  const mutation = useMutation([queryKeys.DeleteComment], deleteComment, {
-    onSuccess: () => queryClient.invalidateQueries([queryKeys.GetComments]),
-  });
+export const useDeleteCommentMutation = (options = {}) => {
+  const mutation = useMutation(
+    [queryKeys.DeleteComment],
+    deleteComment,
+    options,
+  );
 
   return mutation;
 };

--- a/src/hooks/query/comments/useCommentsMutation.ts
+++ b/src/hooks/query/comments/useCommentsMutation.ts
@@ -1,16 +1,21 @@
+import { queryClient } from '@/react-query/queryClient';
 import { queryKeys } from '@/react-query/queryKeys';
 import { useMutation } from '@tanstack/react-query';
 
 import { deleteComment, postComment } from '@/api/comments';
 
 export const usePostCommentMutation = () => {
-  const mutation = useMutation([queryKeys.PostComment], postComment);
+  const mutation = useMutation([queryKeys.PostComment], postComment, {
+    onSuccess: () => queryClient.invalidateQueries([queryKeys.GetComments]),
+  });
 
   return mutation;
 };
 
 export const useDeleteCommentMutation = () => {
-  const mutation = useMutation([queryKeys.DeleteComment], deleteComment);
+  const mutation = useMutation([queryKeys.DeleteComment], deleteComment, {
+    onSuccess: () => queryClient.invalidateQueries([queryKeys.GetComments]),
+  });
 
   return mutation;
 };

--- a/src/hooks/query/comments/useCommentsMutation.ts
+++ b/src/hooks/query/comments/useCommentsMutation.ts
@@ -1,0 +1,16 @@
+import { queryKeys } from '@/react-query/queryKeys';
+import { useMutation } from '@tanstack/react-query';
+
+import { deleteComment, postComment } from '@/api/comments';
+
+export const usePostCommentMutation = () => {
+  const mutation = useMutation([queryKeys.PostComment], postComment);
+
+  return mutation;
+};
+
+export const useDeleteCommentMutation = () => {
+  const mutation = useMutation([queryKeys.DeleteComment], deleteComment);
+
+  return mutation;
+};

--- a/src/hooks/query/comments/useCommentsQuery.ts
+++ b/src/hooks/query/comments/useCommentsQuery.ts
@@ -1,0 +1,20 @@
+import { queryKeys } from '@/react-query/queryKeys';
+import { useQuery } from '@tanstack/react-query';
+
+import { getComments } from '@/api/comments';
+
+export const useCommentsQuery = ({
+  slug,
+  headers = {},
+  options = {},
+}: {
+  slug: string;
+  headers?: HeadersInit;
+  options?: RequestInit;
+}) => {
+  const query = useQuery([queryKeys.GetComments], () =>
+    getComments({ slug, headers, options }),
+  );
+
+  return query;
+};

--- a/src/hooks/query/comments/useCommentsQuery.ts
+++ b/src/hooks/query/comments/useCommentsQuery.ts
@@ -12,7 +12,7 @@ export const useCommentsQuery = ({
   headers?: HeadersInit;
   options?: RequestInit;
 }) => {
-  const query = useQuery([queryKeys.GetComments], () =>
+  const query = useQuery([queryKeys.GetComments, slug], () =>
     getComments({ slug, headers, options }),
   );
 

--- a/src/hooks/query/favorites/useFavoritesMutation.ts
+++ b/src/hooks/query/favorites/useFavoritesMutation.ts
@@ -3,14 +3,18 @@ import { useMutation } from '@tanstack/react-query';
 
 import { deleteFavorite, postFavorite } from '@/api/favorites';
 
-export const usePostFavoriteMutation = () => {
-  const mutation = useMutation([queryKeys.PostFavorite], postFavorite);
+export const usePostFavoriteMutation = (options = {}) => {
+  const mutation = useMutation([queryKeys.PostFavorite], postFavorite, options);
 
   return mutation;
 };
 
-export const useDeleteFavoriteMutation = () => {
-  const mutation = useMutation([queryKeys.DeleteFavorite], deleteFavorite);
+export const useDeleteFavoriteMutation = (options = {}) => {
+  const mutation = useMutation(
+    [queryKeys.DeleteFavorite],
+    deleteFavorite,
+    options,
+  );
 
   return mutation;
 };

--- a/src/hooks/query/favorites/useFavoritesMutation.ts
+++ b/src/hooks/query/favorites/useFavoritesMutation.ts
@@ -1,0 +1,16 @@
+import { queryKeys } from '@/react-query/queryKeys';
+import { useMutation } from '@tanstack/react-query';
+
+import { deleteFavorite, postFavorite } from '@/api/favorites';
+
+export const usePostFavoriteMutation = () => {
+  const mutation = useMutation([queryKeys.PostFavorite], postFavorite);
+
+  return mutation;
+};
+
+export const useDeleteFavoriteMutation = () => {
+  const mutation = useMutation([queryKeys.DeleteFavorite], deleteFavorite);
+
+  return mutation;
+};

--- a/src/hooks/query/profile/useProfileMutation.ts
+++ b/src/hooks/query/profile/useProfileMutation.ts
@@ -3,16 +3,21 @@ import { useMutation } from '@tanstack/react-query';
 
 import { deleteUnfollowUser, postFollowUser } from '@/api/profile';
 
-export const usePostFollowUserMutation = () => {
-  const mutation = useMutation([queryKeys.PostFollowUser], postFollowUser);
+export const usePostFollowUserMutation = (options = {}) => {
+  const mutation = useMutation(
+    [queryKeys.PostFollowUser],
+    postFollowUser,
+    options,
+  );
 
   return mutation;
 };
 
-export const useDeleteUnFollowUserMutation = () => {
+export const useDeleteUnFollowUserMutation = (options = {}) => {
   const mutation = useMutation(
     [queryKeys.DeleteUnfollowUser],
     deleteUnfollowUser,
+    options,
   );
 
   return mutation;

--- a/src/hooks/query/tags/useTagsQuery.ts
+++ b/src/hooks/query/tags/useTagsQuery.ts
@@ -1,0 +1,18 @@
+import { queryKeys } from '@/react-query/queryKeys';
+import { useQuery } from '@tanstack/react-query';
+
+import { getTags } from '@/api/tags';
+
+export const useTagsQuery = ({
+  headers = {},
+  options = {},
+}: {
+  headers?: HeadersInit;
+  options?: RequestInit;
+}) => {
+  const query = useQuery([queryKeys.GetTags], () =>
+    getTags({ headers, options }),
+  );
+
+  return query;
+};

--- a/src/hooks/query/tags/useTagsQuery.ts
+++ b/src/hooks/query/tags/useTagsQuery.ts
@@ -3,13 +3,12 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getTags } from '@/api/tags';
 
-export const useTagsQuery = ({
-  headers = {},
-  options = {},
-}: {
-  headers?: HeadersInit;
-  options?: RequestInit;
-}) => {
+export const useTagsQuery = (
+  { headers, options } = {
+    headers: {},
+    options: {},
+  },
+) => {
   const query = useQuery([queryKeys.GetTags], () =>
     getTags({ headers, options }),
   );

--- a/src/pageComponents/HomePageMain.tsx
+++ b/src/pageComponents/HomePageMain.tsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { ReactNode, useCallback, useEffect, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 
 import { FEED_PER_PAGE, INITIAL_PAGE } from '@/constants/api';
 
@@ -27,7 +27,9 @@ const HomePageMain = () => {
 
   const user = useUserStore((state) => state.user);
 
-  const [feedType, setFeedType] = useState<string>();
+  const [feedType, setFeedType] = useState<string>(
+    user.email ? 'your' : 'global',
+  );
   const [page, setPage] = useState<number>(1);
 
   const [myFeedTabElement, setMyFeedTabElement] = useState<ReactNode>(<></>);
@@ -108,14 +110,6 @@ const HomePageMain = () => {
     setTagFeedTabElement(tagFeedTabElement);
     setFeedType(popularTag);
   };
-
-  useEffect(() => {
-    if (user.email) {
-      setFeedType('your');
-    } else {
-      setFeedType('global');
-    }
-  }, [user]);
 
   useEffect(() => {
     const page = searchParams?.get('page') ?? INITIAL_PAGE;

--- a/src/pageComponents/HomePageMain.tsx
+++ b/src/pageComponents/HomePageMain.tsx
@@ -6,7 +6,7 @@ import { FeedsResponse } from '@/types/api/articles';
 import classNames from 'classnames';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { ReactNode, useEffect, useState } from 'react';
 
 import { INITIAL_PAGE } from '@/constants/api';
@@ -18,6 +18,7 @@ interface Props {
 const HomePageMain = ({ feeds }: Props) => {
   // server-side fetch - server component만 이용
 
+  const { push: navigate } = useRouter();
   const searchParams = useSearchParams();
 
   const user = useUserStore((state) => state.user);
@@ -28,6 +29,13 @@ const HomePageMain = ({ feeds }: Props) => {
   const [tabsElement, setTabsElement] = useState<ReactNode>();
 
   const { articlesCount, articles } = feeds;
+
+  const favoriteArticle = () => {
+    if (!user.email) {
+      navigate('/login');
+      return;
+    }
+  };
 
   useEffect(() => {
     let type = searchParams?.get('type') ?? 'your';
@@ -134,7 +142,10 @@ const HomePageMain = ({ feeds }: Props) => {
                         </Link>
                         <span className="date">{createdAt}</span>
                       </div>
-                      <button className="btn btn-outline-primary btn-sm pull-xs-right">
+                      <button
+                        className="btn btn-outline-primary btn-sm pull-xs-right"
+                        onClick={favoriteArticle}
+                      >
                         <i className="ion-heart"></i> {favoritesCount}
                       </button>
                     </div>

--- a/src/pageComponents/HomePageMain.tsx
+++ b/src/pageComponents/HomePageMain.tsx
@@ -15,6 +15,7 @@ import {
   useDeleteFavoriteMutation,
   usePostFavoriteMutation,
 } from '@/hooks/query/favorites/useFavoritesMutation';
+import { useTagsQuery } from '@/hooks/query/tags/useTagsQuery';
 
 interface Props {
   feeds: FeedsResponse;
@@ -80,6 +81,8 @@ const HomePageMain = ({ feeds }: Props) => {
       );
     }
   };
+
+  const { data: popularTags, isLoading: isPopularTagsLoading } = useTagsQuery();
 
   useEffect(() => {
     let type = searchParams?.get('type') ?? 'your';
@@ -232,30 +235,21 @@ const HomePageMain = ({ feeds }: Props) => {
                 <p>Popular Tags</p>
 
                 <div className="tag-list">
-                  <Link href="" className="tag-pill tag-default">
-                    programming
-                  </Link>
-                  <Link href="" className="tag-pill tag-default">
-                    javascript
-                  </Link>
-                  <Link href="" className="tag-pill tag-default">
-                    emberjs
-                  </Link>
-                  <Link href="" className="tag-pill tag-default">
-                    angularjs
-                  </Link>
-                  <Link href="" className="tag-pill tag-default">
-                    react
-                  </Link>
-                  <Link href="" className="tag-pill tag-default">
-                    mean
-                  </Link>
-                  <Link href="" className="tag-pill tag-default">
-                    node
-                  </Link>
-                  <Link href="" className="tag-pill tag-default">
-                    rails
-                  </Link>
+                  {!isPopularTagsLoading && popularTags ? (
+                    <>
+                      {popularTags.tags.map((popularTag) => (
+                        <Link
+                          key={popularTag}
+                          href=""
+                          className="tag-pill tag-default"
+                        >
+                          {popularTag}
+                        </Link>
+                      ))}
+                    </>
+                  ) : (
+                    <>Loading tags...</>
+                  )}
                 </div>
               </div>
             </div>

--- a/src/pageComponents/article/[slug]/ArticleDetailPageMain.tsx
+++ b/src/pageComponents/article/[slug]/ArticleDetailPageMain.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { queryClient } from '@/react-query/queryClient';
+import { queryKeys } from '@/react-query/queryKeys';
 import { useUserStore } from '@/stores/users';
 import { ArticleResponse } from '@/types/api/articles';
 import classNames from 'classnames';
@@ -149,8 +151,12 @@ const ArticleDetailPageMain = ({ article }: Props) => {
   const commentRef = useRef<HTMLTextAreaElement | null>(null);
 
   const { mutate: postCommentMutate, isLoading: isPostCommentLoading } =
-    usePostCommentMutation();
-  const { mutate: deleteCommentMutate } = useDeleteCommentMutation();
+    usePostCommentMutation({
+      onSuccess: () => queryClient.invalidateQueries([queryKeys.GetComments]),
+    });
+  const { mutate: deleteCommentMutate } = useDeleteCommentMutation({
+    onSuccess: () => queryClient.invalidateQueries([queryKeys.GetComments]),
+  });
 
   const handleComment = (type: 'Post' | 'Delete', id?: number) => {
     if (!commentRef.current) {

--- a/src/pageComponents/article/[slug]/ArticleDetailPageMain.tsx
+++ b/src/pageComponents/article/[slug]/ArticleDetailPageMain.tsx
@@ -50,6 +50,13 @@ const ArticleDetailPageMain = ({ article }: Props) => {
     });
   };
 
+  const favoriteCurrentArticle = () => {
+    if (!currentUser.email) {
+      router.push('/login');
+      return;
+    }
+  };
+
   useEffect(() => {
     const authorProfileMenus = isAuthor ? (
       <>
@@ -74,9 +81,12 @@ const ArticleDetailPageMain = ({ article }: Props) => {
           &nbsp; Follow Eric Simons <span className="counter">(10)</span>
         </button>
         &nbsp;&nbsp;
-        <button className="btn btn-sm btn-outline-primary">
+        <button
+          className="btn btn-sm btn-outline-primary"
+          onClick={favoriteCurrentArticle}
+        >
           <i className="ion-heart"></i>
-          &nbsp; Favorite Post <span className="counter">(29)</span>
+          &nbsp; Favorite Article <span className="counter">(29)</span>
         </button>
       </>
     );

--- a/src/pageComponents/article/[slug]/ArticleDetailPageMain.tsx
+++ b/src/pageComponents/article/[slug]/ArticleDetailPageMain.tsx
@@ -54,7 +54,7 @@ const ArticleDetailPageMain = ({ article }: Props) => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [currentAuthorProfileMenus, setCurrentAuthorProfileMenus] =
     useState<ReactNode>(<></>);
-  const [currentCommentMenus, setCurrentCommentMenus] = useState<ReactNode>(
+  const [currentCommentForm, setCurrentCommentForm] = useState<ReactNode>(
     <></>,
   );
 
@@ -238,26 +238,47 @@ const ArticleDetailPageMain = ({ article }: Props) => {
   ]);
 
   useEffect(() => {
-    const currentCommentMenus = (
-      <div className="card-footer">
-        <Image
-          src={currentUser.image}
-          alt={currentUser.username}
-          width={30}
-          height={30}
-          className="comment-author-img"
-        />
-        <button
-          className="btn btn-sm btn-primary"
-          type="button"
-          onClick={() => handleComment('Post')}
-        >
-          Post Comment
-        </button>
-      </div>
-    );
-    setCurrentCommentMenus(currentCommentMenus);
-  }, [currentUser]);
+    if (currentUser.username) {
+      const currentCommentForm = (
+        <form className="card comment-form">
+          <div className="card-block">
+            <textarea
+              ref={commentRef}
+              className="form-control"
+              placeholder="Write a comment..."
+              rows={3}
+              disabled={isPostCommentLoading}
+            ></textarea>
+          </div>
+          <div className="card-footer">
+            <Image
+              src={currentUser.image}
+              alt={currentUser.username}
+              width={30}
+              height={30}
+              className="comment-author-img"
+            />
+            <button
+              className="btn btn-sm btn-primary"
+              type="button"
+              onClick={() => handleComment('Post')}
+            >
+              Post Comment
+            </button>
+          </div>
+        </form>
+      );
+      setCurrentCommentForm(currentCommentForm);
+    } else {
+      const guideLine = (
+        <p>
+          <Link href="/login">Sign in</Link> or{' '}
+          <Link href="/register">Sign up</Link> to add comments on this article.
+        </p>
+      );
+      setCurrentCommentForm(guideLine);
+    }
+  }, [currentUser, isPostCommentLoading]);
 
   return (
     <div className="article-page">
@@ -323,18 +344,7 @@ const ArticleDetailPageMain = ({ article }: Props) => {
 
         <div className="row">
           <div className="col-xs-12 col-md-8 offset-md-2">
-            <form className="card comment-form">
-              <div className="card-block">
-                <textarea
-                  ref={commentRef}
-                  className="form-control"
-                  placeholder="Write a comment..."
-                  rows={3}
-                  disabled={isPostCommentLoading}
-                ></textarea>
-              </div>
-              {currentCommentMenus}
-            </form>
+            {currentCommentForm}
 
             {!isCommentsLoading && comments ? (
               comments?.comments.map(

--- a/src/pageComponents/profile/[username]/ProfileUserPageMain.tsx
+++ b/src/pageComponents/profile/[username]/ProfileUserPageMain.tsx
@@ -92,6 +92,13 @@ const ProfileUserPageMain = ({ profile }: Props) => {
     }
   };
 
+  const favoriteArticle = () => {
+    if (!user.email) {
+      navigate('/login');
+      return;
+    }
+  };
+
   useEffect(() => {
     const type = searchParams?.get('type') ?? 'my';
 
@@ -234,7 +241,10 @@ const ProfileUserPageMain = ({ profile }: Props) => {
                             </Link>
                             <span className="date">{createdAt}</span>
                           </div>
-                          <button className="btn btn-outline-primary btn-sm pull-xs-right">
+                          <button
+                            className="btn btn-outline-primary btn-sm pull-xs-right"
+                            onClick={favoriteArticle}
+                          >
                             <i className="ion-heart"></i> {favoritesCount}
                           </button>
                         </div>

--- a/src/react-query/queryKeys.ts
+++ b/src/react-query/queryKeys.ts
@@ -2,4 +2,7 @@ export const queryKeys = {
   GetArticles: 'GetArticles',
   PostFollowUser: 'PostFollowUser',
   DeleteUnfollowUser: 'DeleteUnfollowUser',
+  GetComments: 'GetComments',
+  PostComment: 'PostComment',
+  DeleteComment: 'DeleteComment',
 } as const;

--- a/src/react-query/queryKeys.ts
+++ b/src/react-query/queryKeys.ts
@@ -5,4 +5,6 @@ export const queryKeys = {
   GetComments: 'GetComments',
   PostComment: 'PostComment',
   DeleteComment: 'DeleteComment',
+  PostFavorite: 'PostFavorite',
+  DeleteFavorite: 'DeleteFavorite',
 } as const;

--- a/src/react-query/queryKeys.ts
+++ b/src/react-query/queryKeys.ts
@@ -7,4 +7,5 @@ export const queryKeys = {
   DeleteComment: 'DeleteComment',
   PostFavorite: 'PostFavorite',
   DeleteFavorite: 'DeleteFavorite',
+  GetTags: 'GetTags',
 } as const;

--- a/src/react-query/queryKeys.ts
+++ b/src/react-query/queryKeys.ts
@@ -1,5 +1,6 @@
 export const queryKeys = {
   GetArticles: 'GetArticles',
+  GetMyFeedArticles: 'GetMyFeedArticles',
   PostFollowUser: 'PostFollowUser',
   DeleteUnfollowUser: 'DeleteUnfollowUser',
   GetComments: 'GetComments',

--- a/src/types/api/comments.d.ts
+++ b/src/types/api/comments.d.ts
@@ -1,13 +1,15 @@
 import { ProfileResponse } from './profile';
 
+export type Comment = {
+  id: number;
+  createdAt: string;
+  updatedAt: string;
+  body: string;
+  author: ProfileResponse['profile'];
+};
+
 export type CommentsResponse = {
-  comments: Array<{
-    id: number;
-    createdAt: string;
-    updatedAt: string;
-    body: string;
-    author: ProfileResponse['profile'];
-  }>;
+  comments: Comment[];
 };
 
 export type CommentPayload = {

--- a/src/types/api/comments.d.ts
+++ b/src/types/api/comments.d.ts
@@ -1,0 +1,21 @@
+import { ProfileResponse } from './profile';
+
+export type CommentsResponse = {
+  comments: Array<{
+    id: number;
+    createdAt: string;
+    updatedAt: string;
+    body: string;
+    author: ProfileResponse['profile'];
+  }>;
+};
+
+export type CommentPayload = {
+  comment: {
+    body: string;
+  };
+};
+
+export type CommentResponse = {
+  comment: CommentResponse['comment'][number];
+};

--- a/src/types/api/favorites.d.ts
+++ b/src/types/api/favorites.d.ts
@@ -1,0 +1,3 @@
+import { FeedResponse } from './articles';
+
+export type FavoritesResponse = FeedResponse;

--- a/src/types/api/tags.d.ts
+++ b/src/types/api/tags.d.ts
@@ -1,0 +1,3 @@
+export type TagsResponse = {
+  tags: string[];
+};


### PR DESCRIPTION
## 📖 작업 배경

- Comments
  - 아티클에 대한 댓글 가져오기
  - 아티클에 대한 댓글 생성하기
  - 아티클에 대한 댓글 삭제하기

- Favorites
  - 아티클 찜하기
  - 아티클 찜 해제하기

- Tags
  - 태그 가져오기
  - 해당 태그에 대한 별도 탭 만들어서 아티클 리스트 보여주기

- 기존 코드 리팩토링
  - 홈페이지

<br/>

## 🛠️ 구현 내용

- fetcher fn / api types 모듈화
  - comments
  - favorites
  - tags

- react query hooks / query Keys 상수 모듈화
  - useQuery, useMutation
  - query Keys 상수

- 게시글 상세 page (app)
  - 현재 로그인한 사용자가 해당 author를 following 하고 있는지 파악하기 위한 로직 추가

- 게시글 상세 pageComponent
  - follow user API 추가
  - 로그인 하지 않았으면 하단에 댓글 폼 없이 가이드라인 제공, 로그인 했으면 댓글 작성할 수 있는 폼 제공

- Comments
  - Get Comments API 추가

- Favorites
  - 로그인하지 않는 사용자가 article favorite 했을 떄 로그인 페이지로 리다이렉트하는 로직 추가
  - 게시글 상세/프로필 상세/홈 페이지에 article favorite API 추가

- Tags
  - Get Tags API 추가

- 홈페이지
  - feed tab type에 따른 조건부 feed article list 가져오기

- 기존 코드 리팩토링
  - 홈 페이지에서 기존 서버 컴포넌트, 쿼리 스트링 type에 따른 분기 로직 모두 제거함 (side effect 많음)
  - 이후 react-query를 이용하여 client side fetch로 로직 구성

<br/>

## 💡 참고사항

- 기존 PR이 머지가 안되어있는 상태에서 커밋을 쭉 올려놔서 현재까지 작업한 내역을 별도 다른 이름의 로컬 브랜치로 백업해두고
   다시 develop에 있던 것을 hard reset 해서 force push 했는데 백업한 다른 이름의 로컬 브랜치가 다 날라가버렸습니다..
   그래서 매우 슬퍼서 눈물날 뻔 했는데 git reflog를 통해 살렸네요 휴.. 
   [참고 아티클](https://seosh817.tistory.com/297)

- 홈페이지 리팩토링을 진행해서 새로고침 시 탭 유지는 아직 되지 않습니다. (your/global/tag tab)

- 개인적으로 vercel로 배포한 [도메인](https://react-world-deploy.vercel.app/)

- 하단은 현재 개인적으로 생각하고 있는 부족한 부분입니다.

```
- 메인/프로필/아티클 상세 - date format
- 코드 리팩토링 (모듈화)
- 메인 - 초기 global feed 탭 전환 시 로딩
- 메인/프로필 - 쿼리 스트링이 아니라 중첩 라우트로 뺐으면?
- 인증/인가, API
    - fetch catch error 모달 사용자 처리
    - next.js middleware 401 등 관련 에러 처리 / 인증 안되었을 때 로그인 페이지로 리다이렉트
    - 인터널 API로 바꾸기 (토큰)
    - 회원가입 중복 422 에러
```
   
<br/>

## 🖼️ 스크린샷

-

<br/>